### PR TITLE
expose proper ports on eris-db image

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -20,11 +20,13 @@ COPY DOCKER/start.sh /usr/local/bin/erisdb-wrapper
 
 # set the repo and install tendermint
 ENV REPO github.com/tendermint/tendermint
-ENV BRANCH permissions
+ENV BRANCH f2f437a328cb3e277bc4ac74e4a1180f1c28efbc
+# note, we want to lock in the same commit number
+#  as eris-db has vendored.
 RUN mkdir --parents $GOPATH/src/$REPO
 WORKDIR $GOPATH/src/$REPO
-RUN git clone https://$REPO . && \
-  git checkout $BRANCH && \
+RUN git clone --quiet https://$REPO . && \
+  git checkout --quiet $BRANCH && \
   go build -o /usr/local/bin/tendermint ./cmd/tendermint
 
 # set the repo and install erisdb
@@ -39,8 +41,8 @@ ENV REPO github.com/eris-ltd/mint-client
 ENV BRANCH master
 RUN mkdir --parents $GOPATH/src/$REPO
 WORKDIR $GOPATH/src/$REPO
-RUN git clone https://$REPO . && \
-  git checkout $BRANCH && \
+RUN git clone --quiet https://$REPO . && \
+  git checkout --quiet $BRANCH && \
   go install ./... && \
   mv $GOPATH/bin/mint* /usr/local/bin && \
   mv ./mint-client /usr/local/bin/
@@ -65,4 +67,8 @@ ENV TMROOT /home/$USER/.eris/blockchains/tendermint
 
 # run tendermint
 # really should be entrypoint but broken in API 1.19
+# ports: 1337:eris-db API; 46656:mint-peer; 46657:mint-rpc
+EXPOSE 1337
+EXPOSE 46656
+EXPOSE 46657
 CMD ["erisdb-wrapper"]

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ deployment:
       - docker push eris/erisdb:0.10
   unstable:
     branch: develop
-    comands:
+    commands:
       - "export ERISDB_BUILD_BRANCH=$CIRCLE_BRANCH && DOCKER/build.sh"
       - docker tag eris/erisdb:$CIRCLE_BRANCH eris/db:unstable
       - docker push eris/erisdb:unstable


### PR DESCRIPTION
please note, this locks in mint at the commit number below (current master) which is what we should do with the vendoring when we have a chance. 

am not saying that's the right commit, but we should be using the same commit in the dockerfile (L23) as we do for vendoring. 