### PR TITLE
upgrades to docker sequencine

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -10,23 +10,17 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 #-----------------------------------------------------------------------------
-# start script
-
-# install the wrapper/start script
-COPY DOCKER/start.sh /usr/local/bin/erisdb-wrapper
-
-#-----------------------------------------------------------------------------
 # install tendermint
 
-# set the repo and install tendermint
+# set the repo and install tendermint -- should track vendored commit
 ENV REPO github.com/tendermint/tendermint
-ENV BRANCH 4ee387d0770ed379e2d524f7077938517b38cd7c
+ENV COMMIT 4ee387d0770ed379e2d524f7077938517b38cd7c
 # note, we want to lock in the same commit number
 #  as eris-db has vendored.
 RUN mkdir --parents $GOPATH/src/$REPO
 WORKDIR $GOPATH/src/$REPO
 RUN git clone --quiet https://$REPO . && \
-  git checkout --quiet $BRANCH && \
+  git checkout --quiet $COMMIT && \
   go build -o /usr/local/bin/tendermint ./cmd/tendermint
 
 #-----------------------------------------------------------------------------
@@ -58,18 +52,24 @@ RUN git clone --quiet https://$REPO . && \
 
 RUN rm -rf $GOPATH/src/* && \
   unset REPO && \
+  unset COMMIT && \
   unset BRANCH
+
+#-----------------------------------------------------------------------------
+# start script
+
+# install the wrapper/start script
+COPY DOCKER/start.sh /usr/local/bin/erisdb-wrapper
 
 #-----------------------------------------------------------------------------
 # chain manager scripts and default mint config
 
-ENV ECM_PATH /usr/local/lib/ecm/
+ENV ECM_PATH /usr/local/lib/ecm
 RUN mkdir -p $ECM_PATH
-COPY DOCKER/chain_* $ECM_PATH
-COPY DOCKER/config.toml $ECM_PATH
-COPY DOCKER/version.sh $ECM_PATH
+COPY DOCKER/chain_* $ECM_PATH/
+COPY DOCKER/config.toml $ECM_PATH/
+COPY DOCKER/version.sh $ECM_PATH/
 RUN chown -R eris $ECM_PATH
-
 
 #-----------------------------------------------------------------------------
 # root dir
@@ -82,9 +82,8 @@ RUN mkdir --parents /home/$USER/.eris/blockchains/tendermint
 ENV TMROOT /home/$USER/.eris/blockchains/tendermint
 
 # run tendermint
-# really should be entrypoint but broken in API 1.19
 # ports: 1337:eris-db API; 46656:mint-peer; 46657:mint-rpc
 EXPOSE 1337
 EXPOSE 46656
 EXPOSE 46657
-CMD ["erisdb-wrapper"]
+ENTRYPOINT ["erisdb-wrapper"]

--- a/DOCKER/build.sh
+++ b/DOCKER/build.sh
@@ -1,24 +1,26 @@
 #!/bin/sh
 
-base=github.com/eris-ltd/eris-db
-release="0.10"
-repo=$GOPATH/src/$base
-branch=${ERISDB_BUILD_BRANCH:=develop}
+release_maj="0.10"
+release_min="0.10.1"
+
 start=`pwd`
+branch=${ERISDB_BUILD_BRANCH:=master}
+base=github.com/eris-ltd/eris-db
+repo=$GOPATH/src/$base
 
 cd $repo
 
-if [ "$DEV" != "true" ]; then
-	git checkout $branch
-	git pull origin
-fi
+# if [ "$DEV" != "true" ]; then
+# 	git checkout $branch
+# 	git pull origin
+# fi
 
 if [ "$ERISDB_BUILD_BRANCH" = "master" ]; then
-  docker build -t eris/erisdb:$release -f DOCKER/Dockerfile .
-  docker tag eris/erisdb:$release eris/erisdb:latest
+  docker build -t eris/erisdb:latest -f DOCKER/Dockerfile .
+  docker tag -f eris/erisdb:latest eris/erisdb:$release_maj
+  docker tag -f eris/erisdb:latest eris/erisdb:$release_min
 else
   docker build -t eris/erisdb:$branch -f DOCKER/Dockerfile .
 fi
-
 
 cd $start

--- a/DOCKER/chain_new.sh
+++ b/DOCKER/chain_new.sh
@@ -16,6 +16,7 @@ else
 	cp genesis.json $CHAIN_DIR/genesis.json
 fi
 
+
 # if no config was given, lay one with the given options
 if [ ! -f $CHAIN_DIR/config.toml ]; then
 	echo "running mintconfig $CONFIG_OPTS"

--- a/DOCKER/start.sh
+++ b/DOCKER/start.sh
@@ -17,9 +17,8 @@ if [ "$CHAIN_ID" = "" ]; then
 	exit 1
 fi
 
-
 # TODO: deal with chain numbers
-# and eg. $CONTAINER_NAME 
+# and eg. $CONTAINER_NAME
 CHAIN_DIR="/home/$USER/.eris/blockchains/$CHAIN_ID"
 
 # set the tendermint directory
@@ -43,13 +42,57 @@ if [ ! $ECM_PATH ]; then
 	ECM_PATH=.
 fi
 
+#------------------------------------------------
+# dump key files if they are in env vars
+
+if [ -z "$KEY" ]
+then
+  echo "No Key Given"
+else
+  echo "Key Given. Writing priv_validator.json"
+	echo "$KEY" >> $CHAIN_DIR/priv_validator.json
+fi
+
+if [ -z "$GENESIS" ]
+then
+  echo "No Genesis Given"
+else
+  echo "Genesis Given. Writing genesis.json"
+	echo "$GENESIS" > $CHAIN_DIR/genesis.json
+fi
+
+if [ -z "$GENESIS_CSV" ]
+then
+  echo "No Genesis_CSV Given"
+else
+  echo "Genesis_CSV Given. Writing genesis.csv"
+  echo "$GENESIS_CSV" > $CHAIN_DIR/genesis.csv
+fi
+
+if [ -z "$CHAIN_CONFIG" ]
+then
+  echo "No Chain Config Given"
+else
+  echo "Chain Config Given. Writing config.toml"
+	echo "$CHAIN_CONFIG" > $CHAIN_DIR/config.toml
+fi
+
+if [ -z "$SERVER_CONFIG" ]
+then
+  echo "No Server Config Given"
+else
+  echo "Server Config Given. Writing server_conf.toml"
+	echo "$SERVER_CONFIG" > $CHAIN_DIR/server_conf.toml
+fi
+
+#------------------------------------------------
+# export important vars
 
 export TMROOT
 export CHAIN_DIR
 export NODE_ADDR
 export NODE_HOST
 export ECM_PATH  # set by Dockerfile
-
 
 # print the version
 bash $ECM_PATH/version.sh


### PR DESCRIPTION
enables $KEYS, $GENESIS, $GENESIS_CSV, $CHAIN_CONF,
and $SERVER_CONF to be given as environment variables

the master script will dump those into the appropriate
$CHAINDIR location.

changed "erisdb-wrapper" to entry point (which is where
it should have always been)

added major release and minor release (which will need
to be updated) to the DOCKER/build.sh script.