### PR TITLE
move docker login to deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,6 @@ dependencies:
     - sudo service docker start
     - "sudo apt-get update && sudo apt-get install -y libgmp3-dev"
     - sudo curl -sSL -o /usr/bin/docker-machine https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine_linux-amd64; sudo chmod 0755 /usr/bin/docker-machine
-    - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
     - "cd ./cmd/erisdb && go get -d && go build"
     - "mv ~/eris-db/cmd/erisdb/erisdb ~/bin"
     - chmod +x ~/bin/erisdb
@@ -30,10 +29,12 @@ deployment:
   master:
     branch: master
     commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - DOCKER/build.sh
       - docker push quay.io/eris/erisdb
   develop:
     branch: develop
     commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - DOCKER/build.sh
       - docker push quay.io/eris/erisdb


### PR DESCRIPTION
1. for PRs into development no deployment is needed, and the docker login command is not needed
2. on merge into develop branch, [expected] deployment proceeds as normal with docker login