### PR TITLE
quick patch to develop_tmsp, separating the config files;

### DIFF
--- a/erisdb/serve.go
+++ b/erisdb/serve.go
@@ -67,7 +67,7 @@ func ServeErisDB(workDir string, inProc bool) (*server.ServeProcess, error) {
 
 	// Get an erisdb configuration
 	var edbConf *edbcfg.ErisDBConfig
-	edbConfPath := path.Join(workDir, "config.toml")
+	edbConfPath := path.Join(workDir, "server_config.toml")
 	if !FileExists(edbConfPath) {
 		log.Info("No server configuration, using default.")
 		log.Info("Writing to: " + edbConfPath)


### PR DESCRIPTION
this is needed to avoid edb to assume that tendermints written config file is edbs config file
the current code is highly unsafe as a differently structured config file will produce a runtime error

this should have been addressed in #118 

I am also aware of @ebuchman suggestion in #118; but this is not the direction to take as the unified config file does not work:
1. tendermint is configureable through a configuration file (not per se through an exposed api), and writes to this config file (eg `tendermint init`); this is the first reason to separate the config files
2. edb should be able to treat the modules (eg tendermint as consensus) as functional black boxes, and should not have to update it's config file to cater internal changes of modules and their config files;

edb will have its config file and this config will specify the modules their versions and where their separate working directories and config files are.  A combined config file format is unversionable/unmanageable