### PR TITLE
re-introduce deployment from develop branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,3 +36,4 @@ deployment:
     branch: develop
     commands:
       - DOCKER/build.sh
+      - docker push quay.io/eris/erisdb


### PR DESCRIPTION
This might fix the cause of the failing E-PM tests (I had disabled deployment of the containers on develop branch)