### PR TITLE
changes to fix permissions -> evm connection

### DIFF
--- a/Godeps/_workspace/src/github.com/tendermint/tendermint/permission/types/permissions.go
+++ b/Godeps/_workspace/src/github.com/tendermint/tendermint/permission/types/permissions.go
@@ -135,7 +135,7 @@ func (aP *AccountPermissions) HasRole(role string) bool {
 
 // Returns true if the role is added, and false if it already exists
 func (aP *AccountPermissions) AddRole(role string) bool {
-	role = string(LeftPadBytes([]byte(role), 32))
+	role = string(RightPadBytes([]byte(role), 32))
 	for _, r := range aP.Roles {
 		if r == role {
 			return false

--- a/Godeps/_workspace/src/github.com/tendermint/tendermint/vm/snative.go
+++ b/Godeps/_workspace/src/github.com/tendermint/tendermint/vm/snative.go
@@ -53,13 +53,14 @@ contract Permissions {
 
 // function identifiers from the solidity abi
 var PermsMap = map[string]SNativeFuncDescription{
-	"054556ac": SNativeFuncDescription{"has_role", 2, ptypes.HasRole, has_role},
+	//"054556ac": SNativeFuncDescription{"has_role", 2, ptypes.HasRole, has_role},
+	"e8145855": SNativeFuncDescription{"has_role", 2, ptypes.HasRole, has_role},
 	"180d26f2": SNativeFuncDescription{"unset_base", 2, ptypes.UnsetBase, unset_base},
 	"3a3fcc59": SNativeFuncDescription{"set_global", 2, ptypes.SetGlobal, set_global},
-	"9a1c4141": SNativeFuncDescription{"add_role", 2, ptypes.AddRole, add_role},
+	"3fbf7da5": SNativeFuncDescription{"add_role", 2, ptypes.AddRole, add_role},
 	"9ea53314": SNativeFuncDescription{"set_base", 3, ptypes.SetBase, set_base},
 	"bb37737a": SNativeFuncDescription{"has_base", 2, ptypes.HasBase, has_base},
-	"ded3350a": SNativeFuncDescription{"rm_role", 2, ptypes.RmRole, rm_role},
+	"28fd0194": SNativeFuncDescription{"rm_role", 2, ptypes.RmRole, rm_role},
 }
 
 func permissionsContract(appState AppState, caller *Account, args []byte, gas *int64) (output []byte, err error) {

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,7 @@
 
 package version
 
-const VERSION = "0.12.0"
 const TENDERMINT_VERSION = "0.5.0"
+// IMPORTANT: Eris-DB version must be on the last line of this file for
+// the deployment script DOCKER/build.sh to pick up the right label.
+const VERSION = "0.12.0"


### PR DESCRIPTION
Just to make sure they are on develop-0.12.0 with the old godeps as well;
for the Build script to pick up the right version number for labeling, the version number needs to be on the last line of version/version.go