### PR TITLE
Issue #143 concurrency bug in godeps/tendermint/event RemoveListener

### DIFF
--- a/Godeps/_workspace/src/github.com/tendermint/tendermint/events/events.go
+++ b/Godeps/_workspace/src/github.com/tendermint/tendermint/events/events.go
@@ -69,12 +69,14 @@ func (evsw *EventSwitch) RemoveListener(listenerID string) {
 	// Get and remove listener
 	evsw.mtx.RLock()
 	listener := evsw.listeners[listenerID]
-	delete(evsw.listeners, listenerID)
 	evsw.mtx.RUnlock()
-
 	if listener == nil {
 		return
 	}
+
+	evsw.mtx.Lock()
+	delete(evsw.listeners, listenerID)
+	evsw.mtx.Unlock()
 
 	// Remove callback for each event.
 	listener.SetRemoved()


### PR DESCRIPTION
fixes #143; godeps/tendermint/event.go: claim full lock on delete listener; refer to https://github.com/tendermint/go-events/pull/4 for more details.

As a lot of work has been put into moving Eris-DB to work with the up-to-date Tendermint, and the bug is tested and corrected there; we only apply a hot-patch here.