### PR TITLE
Add receipts and fix BroadcastTx tests

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -28,7 +28,6 @@ import (
 	ptypes "github.com/eris-ltd/eris-db/permission/types"
 	. "github.com/tendermint/go-common"
 	"github.com/tendermint/go-crypto"
-	"github.com/tendermint/go-merkle"
 	"github.com/tendermint/go-wire"
 )
 
@@ -45,12 +44,8 @@ func SignBytes(chainID string, o Signable) []byte {
 	if *err != nil {
 		PanicCrisis(err)
 	}
-	return buf.Bytes()
-}
 
-// HashSignBytes is a convenience method for getting the hash of the bytes of a signable
-func HashSignBytes(chainID string, o Signable) []byte {
-	return merkle.SimpleHashFromBinary(SignBytes(chainID, o))
+	return buf.Bytes()
 }
 
 //-----------------------------------------------------------------------------

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tendermint/tendermint/types"
 
 	account "github.com/eris-ltd/eris-db/account"
-	transaction "github.com/eris-ltd/eris-db/txs"
 )
 
 type (
@@ -158,21 +157,6 @@ type (
 		GasUsed int64  `json:"gas_used"`
 		// TODO ...
 	}
-
-	// UnconfirmedTxs
-	UnconfirmedTxs struct {
-		Txs []transaction.Tx `json:"txs"`
-	}
-
-	// BroadcastTx or Transact
-	Receipt struct {
-		TxHash          []byte `json:"tx_hash"`
-		CreatesContract uint8  `json:"creates_contract"`
-		ContractAddr    []byte `json:"contract_addr"`
-	}
-
-	TransactionResult struct {
-	}
 )
 
 func FromRoundState(rs *csus.RoundState) *ConsensusState {
@@ -191,7 +175,16 @@ func FromRoundState(rs *csus.RoundState) *ConsensusState {
 //------------------------------------------------------------------------------
 // copied in from NameReg
 
-type ResultListNames struct {
-	BlockHeight int                         `json:"block_height"`
-	Names       []*transaction.NameRegEntry `json:"names"`
-}
+type (
+	NameRegEntry struct {
+		Name    string `json:"name"`    // registered name for the entry
+		Owner   []byte `json:"owner"`   // address that created the entry
+		Data    string `json:"data"`    // data to store under this name
+		Expires int    `json:"expires"` // block at which this entry expires
+	}
+
+	ResultListNames struct {
+		BlockHeight int             `json:"block_height"`
+		Names       []*NameRegEntry `json:"names"`
+	}
+)

--- a/definitions/pipe.go
+++ b/definitions/pipe.go
@@ -28,10 +28,11 @@ import (
 	tendermint_types "github.com/tendermint/tendermint/types"
 
 	account "github.com/eris-ltd/eris-db/account"
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	types "github.com/eris-ltd/eris-db/core/types"
 	event "github.com/eris-ltd/eris-db/event"
 	manager_types "github.com/eris-ltd/eris-db/manager/types"
-	transaction "github.com/eris-ltd/eris-db/txs"
+	"github.com/eris-ltd/eris-db/txs"
 )
 
 type Pipe interface {
@@ -45,6 +46,7 @@ type Pipe interface {
 	// NOTE: [ben] added to Pipe interface on 0.12 refactor
 	GetApplication() manager_types.Application
 	SetConsensusEngine(consensus ConsensusEngine) error
+	GetConsensusEngine() ConsensusEngine
 	// Support for Tendermint RPC
 	GetTendermintPipe() (TendermintPipe, error)
 }
@@ -74,7 +76,7 @@ type Consensus interface {
 }
 
 type NameReg interface {
-	Entry(key string) (*transaction.NameRegEntry, error)
+	Entry(key string) (*core_types.NameRegEntry, error)
 	Entries([]*event.FilterData) (*types.ResultListNames, error)
 }
 
@@ -93,14 +95,14 @@ type Transactor interface {
 	CallCode(fromAddress, code, data []byte) (*types.Call, error)
 	// Send(privKey, toAddress []byte, amount int64) (*types.Receipt, error)
 	// SendAndHold(privKey, toAddress []byte, amount int64) (*types.Receipt, error)
-	BroadcastTx(tx transaction.Tx) (*types.Receipt, error)
+	BroadcastTx(tx txs.Tx) (*txs.Receipt, error)
 	Transact(privKey, address, data []byte, gasLimit,
-		fee int64) (*types.Receipt, error)
+		fee int64) (*txs.Receipt, error)
 	TransactAndHold(privKey, address, data []byte, gasLimit,
-		fee int64) (*transaction.EventDataCall, error)
+		fee int64) (*txs.EventDataCall, error)
 	TransactNameReg(privKey []byte, name, data string, amount,
-		fee int64) (*types.Receipt, error)
-	UnconfirmedTxs() (*types.UnconfirmedTxs, error)
-	SignTx(tx transaction.Tx,
-		privAccounts []*account.PrivAccount) (transaction.Tx, error)
+		fee int64) (*txs.Receipt, error)
+	UnconfirmedTxs() (*txs.UnconfirmedTxs, error)
+	SignTx(tx txs.Tx,
+		privAccounts []*account.PrivAccount) (txs.Tx, error)
 }

--- a/definitions/tendermint_pipe.go
+++ b/definitions/tendermint_pipe.go
@@ -18,8 +18,8 @@ package definitions
 
 import (
 	account "github.com/eris-ltd/eris-db/account"
+	"github.com/eris-ltd/eris-db/txs"
 	rpc_tendermint_types "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
-	transaction "github.com/eris-ltd/eris-db/txs"
 )
 
 // NOTE: [ben] TendermintPipe is the additional pipe to carry over
@@ -57,7 +57,7 @@ type TendermintPipe interface {
 	// TODO: [ben] deprecate as we should not allow unsafe behaviour
 	// where a user is allowed to send a private key over the wire,
 	// especially unencrypted.
-	SignTransaction(tx transaction.Tx,
+	SignTransaction(tx txs.Tx,
 		privAccounts []*account.PrivAccount) (*rpc_tendermint_types.ResultSignTx,
 		error)
 
@@ -67,9 +67,9 @@ type TendermintPipe interface {
 	ListNames() (*rpc_tendermint_types.ResultListNames, error)
 
 	// Memory pool
-	BroadcastTxAsync(transaction transaction.Tx) (*rpc_tendermint_types.ResultBroadcastTx,
+	BroadcastTxAsync(transaction txs.Tx) (*rpc_tendermint_types.ResultBroadcastTx,
 		error)
 
-	BroadcastTxSync(transaction transaction.Tx) (*rpc_tendermint_types.ResultBroadcastTx,
+	BroadcastTxSync(transaction txs.Tx) (*rpc_tendermint_types.ResultBroadcastTx,
 		error)
 }

--- a/definitions/tendermint_pipe.go
+++ b/definitions/tendermint_pipe.go
@@ -18,8 +18,8 @@ package definitions
 
 import (
 	account "github.com/eris-ltd/eris-db/account"
-	"github.com/eris-ltd/eris-db/txs"
 	rpc_tendermint_types "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
+	"github.com/eris-ltd/eris-db/txs"
 )
 
 // NOTE: [ben] TendermintPipe is the additional pipe to carry over

--- a/manager/eris-mint/eris-mint.go
+++ b/manager/eris-mint/eris-mint.go
@@ -23,9 +23,9 @@ import (
 	"sync"
 
 	tendermint_events "github.com/tendermint/go-events"
+	rpcclient "github.com/tendermint/go-rpc/client"
 	wire "github.com/tendermint/go-wire"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
-	rpcclient "github.com/tendermint/go-rpc/client"
 	tmsp "github.com/tendermint/tmsp/types"
 
 	log "github.com/eris-ltd/eris-logger"

--- a/manager/eris-mint/namereg.go
+++ b/manager/eris-mint/namereg.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 
 	sm "github.com/eris-ltd/eris-db/manager/eris-mint/state"
-	"github.com/eris-ltd/eris-db/txs"
 
 	core_types "github.com/eris-ltd/eris-db/core/types"
 	event "github.com/eris-ltd/eris-db/event"
@@ -68,7 +67,7 @@ func newNameReg(erisMint *ErisMint) *namereg {
 	return &namereg{erisMint, ff}
 }
 
-func (this *namereg) Entry(key string) (*txs.NameRegEntry, error) {
+func (this *namereg) Entry(key string) (*core_types.NameRegEntry, error) {
 	st := this.erisMint.GetState() // performs a copy
 	entry := st.GetNameRegEntry(key)
 	if entry == nil {
@@ -79,7 +78,7 @@ func (this *namereg) Entry(key string) (*txs.NameRegEntry, error) {
 
 func (this *namereg) Entries(filters []*event.FilterData) (*core_types.ResultListNames, error) {
 	var blockHeight int
-	var names []*txs.NameRegEntry
+	var names []*core_types.NameRegEntry
 	state := this.erisMint.GetState()
 	blockHeight = state.LastBlockHeight
 	filter, err := this.filterFactory.NewFilter(filters)
@@ -98,7 +97,7 @@ func (this *namereg) Entries(filters []*event.FilterData) (*core_types.ResultLis
 
 type ResultListNames struct {
 	BlockHeight int                 `json:"block_height"`
-	Names       []*txs.NameRegEntry `json:"names"`
+	Names       []*core_types.NameRegEntry `json:"names"`
 }
 
 // Filter for namereg name. This should not be used to get individual entries by name.
@@ -130,7 +129,7 @@ func (this *NameRegNameFilter) Configure(fd *event.FilterData) error {
 }
 
 func (this *NameRegNameFilter) Match(v interface{}) bool {
-	nre, ok := v.(*txs.NameRegEntry)
+	nre, ok := v.(*core_types.NameRegEntry)
 	if !ok {
 		return false
 	}
@@ -169,7 +168,7 @@ func (this *NameRegOwnerFilter) Configure(fd *event.FilterData) error {
 }
 
 func (this *NameRegOwnerFilter) Match(v interface{}) bool {
-	nre, ok := v.(*txs.NameRegEntry)
+	nre, ok := v.(*core_types.NameRegEntry)
 	if !ok {
 		return false
 	}
@@ -205,7 +204,7 @@ func (this *NameRegDataFilter) Configure(fd *event.FilterData) error {
 }
 
 func (this *NameRegDataFilter) Match(v interface{}) bool {
-	nre, ok := v.(*txs.NameRegEntry)
+	nre, ok := v.(*core_types.NameRegEntry)
 	if !ok {
 		return false
 	}
@@ -236,7 +235,7 @@ func (this *NameRegExpiresFilter) Configure(fd *event.FilterData) error {
 }
 
 func (this *NameRegExpiresFilter) Match(v interface{}) bool {
-	nre, ok := v.(*txs.NameRegEntry)
+	nre, ok := v.(*core_types.NameRegEntry)
 	if !ok {
 		return false
 	}

--- a/manager/eris-mint/namereg.go
+++ b/manager/eris-mint/namereg.go
@@ -96,7 +96,7 @@ func (this *namereg) Entries(filters []*event.FilterData) (*core_types.ResultLis
 }
 
 type ResultListNames struct {
-	BlockHeight int                 `json:"block_height"`
+	BlockHeight int                        `json:"block_height"`
 	Names       []*core_types.NameRegEntry `json:"names"`
 }
 

--- a/manager/eris-mint/pipe.go
+++ b/manager/eris-mint/pipe.go
@@ -32,6 +32,7 @@ import (
 
 	account "github.com/eris-ltd/eris-db/account"
 	config "github.com/eris-ltd/eris-db/config"
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	definitions "github.com/eris-ltd/eris-db/definitions"
 	event "github.com/eris-ltd/eris-db/event"
 	vm "github.com/eris-ltd/eris-db/manager/eris-mint/evm"
@@ -39,7 +40,6 @@ import (
 	state_types "github.com/eris-ltd/eris-db/manager/eris-mint/state/types"
 	manager_types "github.com/eris-ltd/eris-db/manager/types"
 	rpc_tendermint_types "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
-	core_types "github.com/eris-ltd/eris-db/core/types"
 	"github.com/eris-ltd/eris-db/txs"
 )
 

--- a/manager/eris-mint/state/block_cache.go
+++ b/manager/eris-mint/state/block_cache.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tendermint/go-merkle"
 
 	acm "github.com/eris-ltd/eris-db/account"
-	"github.com/eris-ltd/eris-db/txs"
+	core_types "github.com/eris-ltd/eris-db/core/types"
 )
 
 func makeStorage(db dbm.DB, root []byte) merkle.Tree {
@@ -120,7 +120,7 @@ func (cache *BlockCache) SetStorage(addr Word256, key Word256, value Word256) {
 //-------------------------------------
 // BlockCache.names
 
-func (cache *BlockCache) GetNameRegEntry(name string) *txs.NameRegEntry {
+func (cache *BlockCache) GetNameRegEntry(name string) *core_types.NameRegEntry {
 	entry, removed, _ := cache.names[name].unpack()
 	if removed {
 		return nil
@@ -133,7 +133,7 @@ func (cache *BlockCache) GetNameRegEntry(name string) *txs.NameRegEntry {
 	}
 }
 
-func (cache *BlockCache) UpdateNameRegEntry(entry *txs.NameRegEntry) {
+func (cache *BlockCache) UpdateNameRegEntry(entry *core_types.NameRegEntry) {
 	name := entry.Name
 	cache.names[name] = nameInfo{entry, false, true}
 }
@@ -278,11 +278,11 @@ func (stjInfo storageInfo) unpack() (Word256, bool) {
 }
 
 type nameInfo struct {
-	name    *txs.NameRegEntry
+	name    *core_types.NameRegEntry
 	removed bool
 	dirty   bool
 }
 
-func (nInfo nameInfo) unpack() (*txs.NameRegEntry, bool, bool) {
+func (nInfo nameInfo) unpack() (*core_types.NameRegEntry, bool, bool) {
 	return nInfo.name, nInfo.removed, nInfo.dirty
 }

--- a/manager/eris-mint/state/execution.go
+++ b/manager/eris-mint/state/execution.go
@@ -474,7 +474,7 @@ func ExecTx(blockCache *BlockCache, tx txs.Tx, runCall bool, evc events.Fireable
 				// Write caller/callee to txCache.
 				txCache.UpdateAccount(caller)
 				txCache.UpdateAccount(callee)
-				vmach := vm.NewVM(txCache, params, caller.Address, txs.TxID(_s.ChainID, tx))
+				vmach := vm.NewVM(txCache, params, caller.Address, txs.TxHash(_s.ChainID, tx))
 				vmach.SetFireable(evc)
 				// NOTE: Call() transfers the value from caller to callee iff call succeeds.
 				ret, err = vmach.Call(caller, callee, code, tx.Data, value, &gas)

--- a/manager/eris-mint/state/execution.go
+++ b/manager/eris-mint/state/execution.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eris-ltd/eris-db/manager/eris-mint/evm"
 	ptypes "github.com/eris-ltd/eris-db/permission/types" // for GlobalPermissionAddress ...
 
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	"github.com/eris-ltd/eris-db/txs"
 )
 
@@ -615,7 +616,7 @@ func ExecTx(blockCache *BlockCache, tx txs.Tx, runCall bool, evc events.Fireable
 				return errors.New(Fmt("Names must be registered for at least %d blocks", txs.MinNameRegistrationPeriod))
 			}
 			// entry does not exist, so create it
-			entry = &txs.NameRegEntry{
+			entry = &core_types.NameRegEntry{
 				Name:    tx.Name,
 				Owner:   tx.Input.Address,
 				Data:    tx.Data,

--- a/manager/eris-mint/state/state.go
+++ b/manager/eris-mint/state/state.go
@@ -10,7 +10,7 @@ import (
 	acm "github.com/eris-ltd/eris-db/account"
 	. "github.com/eris-ltd/eris-db/manager/eris-mint/state/types"
 	ptypes "github.com/eris-ltd/eris-db/permission/types"
-	txs "github.com/eris-ltd/eris-db/txs"
+	"github.com/eris-ltd/eris-db/txs"
 
 	. "github.com/tendermint/go-common"
 	dbm "github.com/tendermint/go-db"
@@ -18,6 +18,7 @@ import (
 	"github.com/tendermint/go-merkle"
 	"github.com/tendermint/go-wire"
 
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -335,7 +336,7 @@ func (s *State) LoadStorage(hash []byte) (storage merkle.Tree) {
 //-------------------------------------
 // State.nameReg
 
-func (s *State) GetNameRegEntry(name string) *txs.NameRegEntry {
+func (s *State) GetNameRegEntry(name string) *core_types.NameRegEntry {
 	_, valueBytes, _ := s.nameReg.Get([]byte(name))
 	if valueBytes == nil {
 		return nil
@@ -344,14 +345,14 @@ func (s *State) GetNameRegEntry(name string) *txs.NameRegEntry {
 	return DecodeNameRegEntry(valueBytes)
 }
 
-func DecodeNameRegEntry(entryBytes []byte) *txs.NameRegEntry {
+func DecodeNameRegEntry(entryBytes []byte) *core_types.NameRegEntry {
 	var n int
 	var err error
 	value := NameRegCodec.Decode(bytes.NewBuffer(entryBytes), &n, &err)
-	return value.(*txs.NameRegEntry)
+	return value.(*core_types.NameRegEntry)
 }
 
-func (s *State) UpdateNameRegEntry(entry *txs.NameRegEntry) bool {
+func (s *State) UpdateNameRegEntry(entry *core_types.NameRegEntry) bool {
 	w := new(bytes.Buffer)
 	var n int
 	var err error
@@ -374,11 +375,11 @@ func (s *State) SetNameReg(nameReg merkle.Tree) {
 }
 
 func NameRegEncoder(o interface{}, w io.Writer, n *int, err *error) {
-	wire.WriteBinary(o.(*txs.NameRegEntry), w, n, err)
+	wire.WriteBinary(o.(*core_types.NameRegEntry), w, n, err)
 }
 
 func NameRegDecoder(r io.Reader, n *int, err *error) interface{} {
-	return wire.ReadBinary(&txs.NameRegEntry{}, r, txs.MaxDataLength, n, err)
+	return wire.ReadBinary(&core_types.NameRegEntry{}, r, txs.MaxDataLength, n, err)
 }
 
 var NameRegCodec = wire.Codec{

--- a/manager/eris-mint/state/state_test.go
+++ b/manager/eris-mint/state/state_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tendermint/tendermint/config/tendermint_test"
 	// tmtypes "github.com/tendermint/tendermint/types"
 
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	"github.com/eris-ltd/eris-db/txs"
 )
 
@@ -252,7 +253,8 @@ func TestNameTxs(t *testing.T) {
 		}
 	}
 
-	validateEntry := func(t *testing.T, entry *txs.NameRegEntry, name, data string, addr []byte, expires int) {
+	validateEntry := func(t *testing.T, entry *core_types.NameRegEntry, name,
+		data string, addr []byte, expires int) {
 
 		if entry == nil {
 			t.Fatalf("Could not find name %s", name)

--- a/manager/eris-mint/transactor.go
+++ b/manager/eris-mint/transactor.go
@@ -120,7 +120,7 @@ func (this *transactor) CallCode(fromAddress, code, data []byte) (
 }
 
 // Broadcast a transaction.
-func (this *transactor) BroadcastTx(tx txs.Tx) (*core_types.Receipt, error) {
+func (this *transactor) BroadcastTx(tx txs.Tx) (*txs.Receipt, error) {
 
 	err := this.erisMint.BroadcastTx(tx)
 	if err != nil {
@@ -137,18 +137,18 @@ func (this *transactor) BroadcastTx(tx txs.Tx) (*core_types.Receipt, error) {
 			contractAddr = state.NewContractAddress(callTx.Input.Address, callTx.Input.Sequence)
 		}
 	}
-	return &core_types.Receipt{txHash, createsContract, contractAddr}, nil
+	return &txs.Receipt{txHash, createsContract, contractAddr}, nil
 }
 
 // Get all unconfirmed txs.
-func (this *transactor) UnconfirmedTxs() (*core_types.UnconfirmedTxs, error) {
+func (this *transactor) UnconfirmedTxs() (*txs.UnconfirmedTxs, error) {
 	// TODO-RPC
-	return &core_types.UnconfirmedTxs{}, nil
+	return &txs.UnconfirmedTxs{}, nil
 }
 
 // Orders calls to BroadcastTx using lock (waits for response from core before releasing)
 func (this *transactor) Transact(privKey, address, data []byte, gasLimit,
-	fee int64) (*core_types.Receipt, error) {
+	fee int64) (*txs.Receipt, error) {
 	var addr []byte
 	if len(address) == 0 {
 		addr = nil
@@ -236,7 +236,7 @@ func (this *transactor) TransactAndHold(privKey, address, data []byte, gasLimit,
 }
 
 func (this *transactor) TransactNameReg(privKey []byte, name, data string,
-	amount, fee int64) (*core_types.Receipt, error) {
+	amount, fee int64) (*txs.Receipt, error) {
 
 	if len(privKey) != 64 {
 		return nil, fmt.Errorf("Private key is not of the right length: %d\n", len(privKey))

--- a/manager/eris-mint/transactor.go
+++ b/manager/eris-mint/transactor.go
@@ -127,7 +127,7 @@ func (this *transactor) BroadcastTx(tx txs.Tx) (*txs.Receipt, error) {
 		return nil, fmt.Errorf("Error broadcasting transaction: %v", err)
 	}
 
-	txHash := txs.TxID(this.chainID, tx)
+	txHash := txs.TxHash(this.chainID, tx)
 	var createsContract uint8
 	var contractAddr []byte
 	// check if creates new contract

--- a/rpc/tendermint/client/client.go
+++ b/rpc/tendermint/client/client.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	acm "github.com/eris-ltd/eris-db/account"
 	core_types "github.com/eris-ltd/eris-db/core/types"
-	"github.com/eris-ltd/eris-db/txs"
 	rpc_types "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
+	"github.com/eris-ltd/eris-db/txs"
 	rpcclient "github.com/tendermint/go-rpc/client"
 	"github.com/tendermint/go-wire"
 )

--- a/rpc/tendermint/client/client.go
+++ b/rpc/tendermint/client/client.go
@@ -1,15 +1,17 @@
 package client
 
 import (
-	rpcclient "github.com/tendermint/go-rpc/client"
-
+	"fmt"
 	acm "github.com/eris-ltd/eris-db/account"
-	ctypes "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	"github.com/eris-ltd/eris-db/txs"
+	rpc_types "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
+	rpcclient "github.com/tendermint/go-rpc/client"
+	"github.com/tendermint/go-wire"
 )
 
-func Status(client rpcclient.Client) (*ctypes.ResultStatus, error) {
-	var res ctypes.ErisDBResult //ResultStatus)
+func Status(client rpcclient.Client) (*rpc_types.ResultStatus, error) {
+	var res rpc_types.ErisDBResult //ResultStatus)
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
@@ -20,11 +22,11 @@ func Status(client rpcclient.Client) (*ctypes.ResultStatus, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultStatus), nil
+	return res.(*rpc_types.ResultStatus), nil
 }
 
 func GenPrivAccount(client rpcclient.Client) (*acm.PrivAccount, error) {
-	var res ctypes.ErisDBResult
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
@@ -35,128 +37,151 @@ func GenPrivAccount(client rpcclient.Client) (*acm.PrivAccount, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultGenPrivAccount).PrivAccount, nil
+	return res.(*rpc_types.ResultGenPrivAccount).PrivAccount, nil
 }
 
 func GetAccount(client rpcclient.Client, addr []byte) (*acm.Account, error) {
-	var res ctypes.ErisDBResult
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
 		_, err = cli.Call("get_account", []interface{}{addr}, &res)
 	case *rpcclient.ClientURI:
-		_, err = cli.Call("get_account", map[string]interface{}{"address": addr}, &res)
+		_, err = cli.Call("get_account", map[string]interface{}{"address": addr},
+			&res)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultGetAccount).Account, nil
+	return res.(*rpc_types.ResultGetAccount).Account, nil
 }
 
-func SignTx(client rpcclient.Client, tx txs.Tx, privAccs []*acm.PrivAccount) (txs.Tx, error) {
+func SignTx(client rpcclient.Client, tx txs.Tx,
+	privAccs []*acm.PrivAccount) (txs.Tx, error) {
 	wrapTx := struct {
 		txs.Tx `json:"unwrap"`
 	}{tx}
-	var res ctypes.ErisDBResult
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
 		_, err = cli.Call("unsafe/sign_tx", []interface{}{wrapTx, privAccs}, &res)
 	case *rpcclient.ClientURI:
-		_, err = cli.Call("unsafe/sign_tx", map[string]interface{}{"tx": wrapTx, "privAccounts": privAccs}, &res)
+		_, err = cli.Call("unsafe/sign_tx", map[string]interface{}{
+			"tx":           wrapTx,
+			"privAccounts": privAccs,
+		}, &res)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultSignTx).Tx, nil
+	return res.(*rpc_types.ResultSignTx).Tx, nil
 }
 
-func BroadcastTx(client rpcclient.Client, tx txs.Tx) (ctypes.Receipt, error) {
+func BroadcastTx(client rpcclient.Client,
+	tx txs.Tx) (txs.Receipt, error) {
 	wrapTx := struct {
 		txs.Tx `json:"unwrap"`
 	}{tx}
-	var res ctypes.ErisDBResult
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
 		_, err = cli.Call("broadcast_tx", []interface{}{wrapTx}, &res)
 	case *rpcclient.ClientURI:
-		_, err = cli.Call("broadcast_tx", map[string]interface{}{"tx": wrapTx}, &res)
+		_, err = cli.Call("broadcast_tx", map[string]interface{}{"tx": wrapTx},
+			&res)
 	}
 	if err != nil {
-		return ctypes.Receipt{}, err
+		return txs.Receipt{}, err
 	}
-	data := res.(*ctypes.ResultBroadcastTx).Data
-	// TODO: unmarshal data to receuipt
-	_ = data
-	return ctypes.Receipt{}, err
+	receiptBytes := res.(*rpc_types.ResultBroadcastTx).Data
+	receipt := txs.Receipt{}
+	err = wire.ReadBinaryBytes(receiptBytes, &receipt)
+	fmt.Printf("rec: %#v\n", receipt)
+	return receipt, err
 
 }
 
-func DumpStorage(client rpcclient.Client, addr []byte) (*ctypes.ResultDumpStorage, error) {
-	var res ctypes.ErisDBResult
+func DumpStorage(client rpcclient.Client,
+	addr []byte) (*rpc_types.ResultDumpStorage, error) {
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
 		_, err = cli.Call("dump_storage", []interface{}{addr}, &res)
 	case *rpcclient.ClientURI:
-		_, err = cli.Call("dump_storage", map[string]interface{}{"address": addr}, &res)
+		_, err = cli.Call("dump_storage", map[string]interface{}{"address": addr},
+			&res)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultDumpStorage), err
+	return res.(*rpc_types.ResultDumpStorage), err
 }
 
 func GetStorage(client rpcclient.Client, addr, key []byte) ([]byte, error) {
-	var res ctypes.ErisDBResult
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
 		_, err = cli.Call("get_storage", []interface{}{addr, key}, &res)
 	case *rpcclient.ClientURI:
-		_, err = cli.Call("get_storage", map[string]interface{}{"address": addr, "key": key}, &res)
+		_, err = cli.Call("get_storage", map[string]interface{}{
+			"address": addr,
+			"key":     key,
+		}, &res)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultGetStorage).Value, nil
+	return res.(*rpc_types.ResultGetStorage).Value, nil
 }
 
-func CallCode(client rpcclient.Client, fromAddress, code, data []byte) (*ctypes.ResultCall, error) {
-	var res ctypes.ErisDBResult
+func CallCode(client rpcclient.Client,
+	fromAddress, code, data []byte) (*rpc_types.ResultCall, error) {
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
 		_, err = cli.Call("call_code", []interface{}{fromAddress, code, data}, &res)
 	case *rpcclient.ClientURI:
-		_, err = cli.Call("call_code", map[string]interface{}{"fromAddress": fromAddress, "code": code, "data": data}, &res)
+		_, err = cli.Call("call_code", map[string]interface{}{
+			"fromAddress": fromAddress,
+			"code":        code,
+			"data":        data,
+		}, &res)
 
 	}
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultCall), err
+	return res.(*rpc_types.ResultCall), err
 }
 
-func Call(client rpcclient.Client, fromAddress, toAddress, data []byte) (*ctypes.ResultCall, error) {
-	var res ctypes.ErisDBResult
+func Call(client rpcclient.Client, fromAddress, toAddress,
+	data []byte) (*rpc_types.ResultCall, error) {
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
 		_, err = cli.Call("call", []interface{}{fromAddress, toAddress, data}, &res)
 	case *rpcclient.ClientURI:
-		_, err = cli.Call("call", map[string]interface{}{"fromAddress": fromAddress, "toAddress": toAddress, "data": data}, &res)
+		_, err = cli.Call("call", map[string]interface{}{
+			"fromAddress": fromAddress,
+			"toAddress":   toAddress,
+			"data":        data,
+		}, &res)
 
 	}
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultCall), err
+	return res.(*rpc_types.ResultCall), err
 }
 
-func GetName(client rpcclient.Client, name string) (*txs.NameRegEntry, error) {
-	var res ctypes.ErisDBResult
+func GetName(client rpcclient.Client, name string) (*core_types.NameRegEntry, error) {
+	var res rpc_types.ErisDBResult
 	var err error
 	switch cli := client.(type) {
 	case *rpcclient.ClientJSONRPC:
@@ -167,5 +192,5 @@ func GetName(client rpcclient.Client, name string) (*txs.NameRegEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultGetName).Entry, nil
+	return res.(*rpc_types.ResultGetName).Entry, nil
 }

--- a/rpc/tendermint/core/routes.go
+++ b/rpc/tendermint/core/routes.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	acm "github.com/eris-ltd/eris-db/account"
-	definitions "github.com/eris-ltd/eris-db/definitions"
-	ctypes "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
 	"github.com/eris-ltd/eris-db/txs"
+	"github.com/eris-ltd/eris-db/definitions"
+	ctypes "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
 	rpc "github.com/tendermint/go-rpc/server"
 )
 
@@ -159,11 +159,11 @@ func (this *TendermintRoutes) ListNamesResult() (ctypes.ErisDBResult, error) {
 }
 
 func (this *TendermintRoutes) GenPrivAccountResult() (ctypes.ErisDBResult, error) {
-	// if r, err := this.tendermintPipe.GenPrivAccount(); err != nil {
-	// 	return nil, err
-	// } else {
-	// 	return r, nil
-	// }
+	//if r, err := this.tendermintPipe.GenPrivAccount(); err != nil {
+	//	return nil, err
+	//} else {
+	//	return r, nil
+	//}
 	return nil, fmt.Errorf("Unimplemented as poor practice to generate private account over unencrypted RPC")
 }
 

--- a/rpc/tendermint/core/routes.go
+++ b/rpc/tendermint/core/routes.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	acm "github.com/eris-ltd/eris-db/account"
-	"github.com/eris-ltd/eris-db/txs"
 	"github.com/eris-ltd/eris-db/definitions"
 	ctypes "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
+	"github.com/eris-ltd/eris-db/txs"
 	rpc "github.com/tendermint/go-rpc/server"
 )
 

--- a/rpc/tendermint/core/types/responses.go
+++ b/rpc/tendermint/core/types/responses.go
@@ -101,7 +101,7 @@ type ResultBroadcastTx struct {
 }
 
 type ResultListUnconfirmedTxs struct {
-	N   int             `json:"n_txs"`
+	N   int      `json:"n_txs"`
 	Txs []txs.Tx `json:"txs"`
 }
 

--- a/rpc/tendermint/core/types/responses.go
+++ b/rpc/tendermint/core/types/responses.go
@@ -2,8 +2,9 @@ package core_types
 
 import (
 	acm "github.com/eris-ltd/eris-db/account"
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	stypes "github.com/eris-ltd/eris-db/manager/eris-mint/state/types"
-	txtypes "github.com/eris-ltd/eris-db/txs"
+	"github.com/eris-ltd/eris-db/txs"
 	"github.com/tendermint/tendermint/types"
 
 	"github.com/tendermint/go-crypto"
@@ -81,8 +82,8 @@ type ResultDumpConsensusState struct {
 }
 
 type ResultListNames struct {
-	BlockHeight int                     `json:"block_height"`
-	Names       []*txtypes.NameRegEntry `json:"names"`
+	BlockHeight int                        `json:"block_height"`
+	Names       []*core_types.NameRegEntry `json:"names"`
 }
 
 type ResultGenPrivAccount struct {
@@ -99,19 +100,13 @@ type ResultBroadcastTx struct {
 	Log  string             `json:"log"`
 }
 
-type Receipt struct {
-	TxHash          []byte `json:"tx_hash"`
-	CreatesContract uint8  `json:"creates_contract"`
-	ContractAddr    []byte `json:"contract_addr"`
-}
-
 type ResultListUnconfirmedTxs struct {
-	N   int          `json:"n_txs"`
-	Txs []txtypes.Tx `json:"txs"`
+	N   int             `json:"n_txs"`
+	Txs []txs.Tx `json:"txs"`
 }
 
 type ResultGetName struct {
-	Entry *txtypes.NameRegEntry `json:"entry"`
+	Entry *core_types.NameRegEntry `json:"entry"`
 }
 
 type ResultGenesis struct {
@@ -119,7 +114,7 @@ type ResultGenesis struct {
 }
 
 type ResultSignTx struct {
-	Tx txtypes.Tx `json:"tx"`
+	Tx txs.Tx `json:"tx"`
 }
 
 type ResultEvent struct {

--- a/rpc/tendermint/test/client_rpc_test.go
+++ b/rpc/tendermint/test/client_rpc_test.go
@@ -15,25 +15,11 @@ func TestHTTPStatus(t *testing.T) {
 	testStatus(t, "HTTP")
 }
 
-func TestHTTPGenPriv(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-	testGenPriv(t, "HTTP")
-}
-
 func TestHTTPGetAccount(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
 	testGetAccount(t, "HTTP")
-}
-
-func TestHTTPSignedTx(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-	testSignedTx(t, "HTTP")
 }
 
 func TestHTTPBroadcastTx(t *testing.T) {
@@ -75,25 +61,11 @@ func TestJSONStatus(t *testing.T) {
 	testStatus(t, "JSONRPC")
 }
 
-func TestJSONGenPriv(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-	testGenPriv(t, "JSONRPC")
-}
-
 func TestJSONGetAccount(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
 	testGetAccount(t, "JSONRPC")
-}
-
-func TestJSONSignedTx(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-	testSignedTx(t, "JSONRPC")
 }
 
 func TestJSONBroadcastTx(t *testing.T) {

--- a/rpc/tendermint/test/client_ws_test.go
+++ b/rpc/tendermint/test/client_ws_test.go
@@ -207,6 +207,6 @@ func TestWSCallCall(t *testing.T) {
 	waitForEvent(t, wsc, eid1, true, func() {
 		tx := makeDefaultCallTx(t, wsTyp, contractAddr2, nil, amt, gasLim, fee)
 		broadcastTx(t, wsTyp, tx)
-		*txid = txs.TxID(chainID, tx)
+		*txid = txs.TxHash(chainID, tx)
 	}, unmarshalValidateCall(user[0].Address, returnVal, txid))
 }

--- a/rpc/tendermint/test/runner/main.go
+++ b/rpc/tendermint/test/runner/main.go
@@ -8,6 +8,7 @@ import (
 )
 
 func main() {
+	//fmt.Printf("%s", util.IsAddress("hello"))
 	fmt.Printf("%s", util.IsAddress("hello"), rpctest.Successor(2))
 	//defer os.Exit(0)
 }

--- a/rpc/tendermint/test/tests.go
+++ b/rpc/tendermint/test/tests.go
@@ -72,8 +72,8 @@ func testBroadcastTx(t *testing.T, typ string) {
 	hasher.Write(goWireBytes)
 	txHashExpected := hasher.Sum(nil)
 	if bytes.Compare(receipt.TxHash, txHashExpected) != 0 {
-		t.Fatalf("The receipt hash '%x' does not equal the ripemd160 hash of the " +
-				"transaction signed bytes calculated in the test: '%x'",
+		t.Fatalf("The receipt hash '%x' does not equal the ripemd160 hash of the "+
+			"transaction signed bytes calculated in the test: '%x'",
 			receipt.TxHash, txHashExpected)
 	}
 }

--- a/rpc/tendermint/test/tests.go
+++ b/rpc/tendermint/test/tests.go
@@ -26,17 +26,6 @@ func testStatus(t *testing.T, typ string) {
 	}
 }
 
-func testGenPriv(t *testing.T, typ string) {
-	client := clients[typ]
-	privAcc, err := edbcli.GenPrivAccount(client)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(privAcc.Address) == 0 {
-		t.Fatal("Failed to generate an address")
-	}
-}
-
 func testGetAccount(t *testing.T, typ string) {
 	acc := getAccount(t, typ, user[0].Address)
 	if acc == nil {
@@ -45,18 +34,6 @@ func testGetAccount(t *testing.T, typ string) {
 	if bytes.Compare(acc.Address, user[0].Address) != 0 {
 		t.Fatalf("Failed to get correct account. Got %x, expected %x", acc.Address, user[0].Address)
 	}
-}
-
-func testSignedTx(t *testing.T, typ string) {
-	amt := int64(100)
-	toAddr := user[1].Address
-	testOneSignTx(t, typ, toAddr, amt)
-
-	toAddr = user[2].Address
-	testOneSignTx(t, typ, toAddr, amt)
-
-	toAddr = user[3].Address
-	testOneSignTx(t, typ, toAddr, amt)
 }
 
 func testOneSignTx(t *testing.T, typ string, addr []byte, amt int64) {
@@ -85,16 +62,9 @@ func testBroadcastTx(t *testing.T, typ string) {
 	if len(receipt.TxHash) == 0 {
 		t.Fatal("Failed to compute tx hash")
 	}
-	pool := node.MempoolReactor().Mempool
-	trnxs := pool.Reap(-1)
-	if len(trnxs) != mempoolCount {
-		t.Fatalf("The mem pool has %d txs. Expected %d", len(trnxs), mempoolCount)
-	}
-	tx2 := txs.DecodeTx(trnxs[mempoolCount-1]).(*txs.SendTx)
 	n, err := new(int), new(error)
 	buf1, buf2 := new(bytes.Buffer), new(bytes.Buffer)
 	tx.WriteSignBytes(chainID, buf1, n, err)
-	tx2.WriteSignBytes(chainID, buf2, n, err)
 	if bytes.Compare(buf1.Bytes(), buf2.Bytes()) != 0 {
 		t.Fatal("inconsistent hashes for mempool tx and sent tx")
 	}

--- a/rpc/v0/json_service.go
+++ b/rpc/v0/json_service.go
@@ -27,7 +27,8 @@ func NewJsonRpcServer(service server.HttpService) *JsonRpcServer {
 }
 
 // Start adds the rpc path to the router.
-func (this *JsonRpcServer) Start(config *server.ServerConfig, router *gin.Engine) {
+func (this *JsonRpcServer) Start(config *server.ServerConfig,
+	router *gin.Engine) {
 	router.POST(config.HTTP.JsonRpcEndpoint, this.handleFunc)
 	this.running = true
 }
@@ -85,13 +86,15 @@ func (this *ErisDbJsonService) Process(r *http.Request, w http.ResponseWriter) {
 
 	// Error when decoding.
 	if errU != nil {
-		this.writeError("Failed to parse request: "+errU.Error(), "", rpc_tendermint.PARSE_ERROR, w)
+		this.writeError("Failed to parse request: "+errU.Error(), "",
+			rpc_tendermint.PARSE_ERROR, w)
 		return
 	}
 
 	// Wrong protocol version.
 	if req.JSONRPC != "2.0" {
-		this.writeError("Wrong protocol version: "+req.JSONRPC, req.Id, rpc_tendermint.INVALID_REQUEST, w)
+		this.writeError("Wrong protocol version: "+req.JSONRPC, req.Id,
+			rpc_tendermint.INVALID_REQUEST, w)
 		return
 	}
 
@@ -137,7 +140,8 @@ func (this *ErisDbJsonService) writeResponse(id string, result interface{}, w ht
 // *************************************** Events ************************************
 
 // Subscribe to an event.
-func (this *ErisDbJsonService) EventSubscribe(request *rpc_tendermint.RPCRequest, requester interface{}) (interface{}, int, error) {
+func (this *ErisDbJsonService) EventSubscribe(request *rpc_tendermint.RPCRequest,
+	requester interface{}) (interface{}, int, error) {
 	param := &EventIdParam{}
 	err := json.Unmarshal(request.Params, param)
 	if err != nil {
@@ -152,7 +156,8 @@ func (this *ErisDbJsonService) EventSubscribe(request *rpc_tendermint.RPCRequest
 }
 
 // Un-subscribe from an event.
-func (this *ErisDbJsonService) EventUnsubscribe(request *rpc_tendermint.RPCRequest, requester interface{}) (interface{}, int, error) {
+func (this *ErisDbJsonService) EventUnsubscribe(request *rpc_tendermint.RPCRequest,
+	requester interface{}) (interface{}, int, error) {
 	param := &SubIdParam{}
 	err := json.Unmarshal(request.Params, param)
 	if err != nil {
@@ -168,7 +173,8 @@ func (this *ErisDbJsonService) EventUnsubscribe(request *rpc_tendermint.RPCReque
 }
 
 // Check subscription event cache for new data.
-func (this *ErisDbJsonService) EventPoll(request *rpc_tendermint.RPCRequest, requester interface{}) (interface{}, int, error) {
+func (this *ErisDbJsonService) EventPoll(request *rpc_tendermint.RPCRequest,
+	requester interface{}) (interface{}, int, error) {
 	param := &SubIdParam{}
 	err := json.Unmarshal(request.Params, param)
 	if err != nil {

--- a/test/mock/mock_web_api_test.g_
+++ b/test/mock/mock_web_api_test.g_
@@ -173,7 +173,7 @@ func (this *MockSuite) TestGetValidators() {
 
 func (this *MockSuite) TestGetNameRegEntry() {
 	resp := this.get("/namereg/" + this.testData.GetNameRegEntry.Input.Name)
-	ret := &txs.NameRegEntry{}
+	ret := &core_types.NameRegEntry{}
 	errD := this.codec.Decode(ret, resp.Body)
 	this.NoError(errD)
 	this.Equal(ret, this.testData.GetNameRegEntry.Output)

--- a/txs/events.go
+++ b/txs/events.go
@@ -72,9 +72,9 @@ type EventDataNewBlock struct {
 
 // All txs fire EventDataTx, but only CallTx might have Return or Exception
 type EventDataTx struct {
-	Tx        Tx     `json:"tx"`
-	Return    []byte `json:"return"`
-	Exception string `json:"exception"`
+	Tx        Tx `json:"tx"`
+	Return    []byte        `json:"return"`
+	Exception string        `json:"exception"`
 }
 
 // EventDataCall fires when we call a contract, and when a contract calls another contract

--- a/txs/events.go
+++ b/txs/events.go
@@ -72,9 +72,9 @@ type EventDataNewBlock struct {
 
 // All txs fire EventDataTx, but only CallTx might have Return or Exception
 type EventDataTx struct {
-	Tx        Tx `json:"tx"`
-	Return    []byte        `json:"return"`
-	Exception string        `json:"exception"`
+	Tx        Tx     `json:"tx"`
+	Return    []byte `json:"return"`
+	Exception string `json:"exception"`
 }
 
 // EventDataCall fires when we call a contract, and when a contract calls another contract

--- a/txs/names.go
+++ b/txs/names.go
@@ -1,6 +1,7 @@
 package txs
 
 import (
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	"regexp"
 )
 
@@ -42,20 +43,8 @@ func NameCostPerBlock(baseCost int64) int64 {
 	return NameBlockCostMultiplier * NameByteCostMultiplier * baseCost
 }
 
-type NameRegEntry struct {
-	Name    string `json:"name"`    // registered name for the entry
-	Owner   []byte `json:"owner"`   // address that created the entry
-	Data    string `json:"data"`    // data to store under this name
-	Expires int    `json:"expires"` // block at which this entry expires
-}
-
-func (entry *NameRegEntry) Copy() *NameRegEntry {
-	entryCopy := *entry
-	return &entryCopy
-}
-
 // XXX: vestige of an older time
 type ResultListNames struct {
-	BlockHeight int             `json:"block_height"`
-	Names       []*NameRegEntry `json:"names"`
+	BlockHeight int                        `json:"block_height"`
+	Names       []*core_types.NameRegEntry `json:"names"`
 }

--- a/txs/tx.go
+++ b/txs/tx.go
@@ -377,10 +377,18 @@ func (tx *PermissionsTx) String() string {
 
 //-----------------------------------------------------------------------------
 
-// This should match the leaf hashes of Block.Data.Hash()'s SimpleMerkleTree.
-func TxID(chainID string, tx Tx) []byte {
+func TxHash(chainID string, tx Tx) []byte {
 	signBytes := acm.SignBytes(chainID, tx)
 	return wire.BinaryRipemd160(signBytes)
+}
+
+// [Silas] Leaving this implementation here for when we transition
+func TxHashFuture(chainID string, tx Tx) []byte {
+	signBytes := acm.SignBytes(chainID, tx)
+	hasher := ripemd160.New()
+	hasher.Write(signBytes)
+	// Calling Sum(nil) just gives us the digest with nothing prefixed
+	return hasher.Sum(nil)
 }
 
 //-----------------------------------------------------------------------------
@@ -417,7 +425,7 @@ func DecodeTx(txBytes []byte) Tx {
 
 func GenerateReceipt(chainId string, tx Tx) Receipt {
 	receipt := Receipt{
-		TxHash:          TxID(chainId, tx),
+		TxHash:          TxHash(chainId, tx),
 		CreatesContract: 0,
 		ContractAddr:    nil,
 	}

--- a/txs/tx.go
+++ b/txs/tx.go
@@ -18,15 +18,15 @@ import (
 )
 
 var (
-	ErrTxInvalidAddress = errors.New("Error invalid address")
-	ErrTxDuplicateAddress = errors.New("Error duplicate address")
-	ErrTxInvalidAmount = errors.New("Error invalid amount")
-	ErrTxInsufficientFunds = errors.New("Error insufficient funds")
+	ErrTxInvalidAddress       = errors.New("Error invalid address")
+	ErrTxDuplicateAddress     = errors.New("Error duplicate address")
+	ErrTxInvalidAmount        = errors.New("Error invalid amount")
+	ErrTxInsufficientFunds    = errors.New("Error insufficient funds")
 	ErrTxInsufficientGasPrice = errors.New("Error insufficient gas price")
-	ErrTxUnknownPubKey = errors.New("Error unknown pubkey")
-	ErrTxInvalidPubKey = errors.New("Error invalid pubkey")
-	ErrTxInvalidSignature = errors.New("Error invalid signature")
-	ErrTxPermissionDenied = errors.New("Error permission denied")
+	ErrTxUnknownPubKey        = errors.New("Error unknown pubkey")
+	ErrTxInvalidPubKey        = errors.New("Error invalid pubkey")
+	ErrTxInvalidSignature     = errors.New("Error invalid signature")
+	ErrTxPermissionDenied     = errors.New("Error permission denied")
 )
 
 type ErrTxInvalidString struct {
@@ -71,9 +71,9 @@ const (
 	TxTypeName = byte(0x03)
 
 	// Validation transactions
-	TxTypeBond = byte(0x11)
-	TxTypeUnbond = byte(0x12)
-	TxTypeRebond = byte(0x13)
+	TxTypeBond    = byte(0x11)
+	TxTypeUnbond  = byte(0x12)
+	TxTypeRebond  = byte(0x13)
 	TxTypeDupeout = byte(0x14)
 
 	// Admin transactions
@@ -82,7 +82,7 @@ const (
 
 // for wire.readReflect
 var _ = wire.RegisterInterface(
-		struct{ Tx }{},
+	struct{ Tx }{},
 	wire.ConcreteType{&SendTx{}, TxTypeSend},
 	wire.ConcreteType{&CallTx{}, TxTypeCall},
 	wire.ConcreteType{&NameTx{}, TxTypeName},
@@ -95,7 +95,7 @@ var _ = wire.RegisterInterface(
 
 //-----------------------------------------------------------------------------
 
-type(
+type (
 	Tx interface {
 		WriteSignBytes(chainID string, w io.Writer, n *int, err *error)
 	}
@@ -191,14 +191,14 @@ func (tx *SendTx) WriteSignBytes(chainID string, w io.Writer, n *int, err *error
 	wire.WriteTo([]byte(Fmt(`,"tx":[%v,{"inputs":[`, TxTypeSend)), w, n, err)
 	for i, in := range tx.Inputs {
 		in.WriteSignBytes(w, n, err)
-		if i != len(tx.Inputs) - 1 {
+		if i != len(tx.Inputs)-1 {
 			wire.WriteTo([]byte(","), w, n, err)
 		}
 	}
 	wire.WriteTo([]byte(`],"outputs":[`), w, n, err)
 	for i, out := range tx.Outputs {
 		out.WriteSignBytes(w, n, err)
-		if i != len(tx.Outputs) - 1 {
+		if i != len(tx.Outputs)-1 {
 			wire.WriteTo([]byte(","), w, n, err)
 		}
 	}
@@ -224,7 +224,7 @@ func (tx *CallTx) String() string {
 }
 
 func NewContractAddress(caller []byte, nonce int) []byte {
-	temp := make([]byte, 32 + 8)
+	temp := make([]byte, 32+8)
 	copy(temp, caller)
 	PutInt64BE(temp[32:], int64(nonce))
 	hasher := ripemd160.New()
@@ -283,7 +283,7 @@ func (tx *BondTx) WriteSignBytes(chainID string, w io.Writer, n *int, err *error
 	wire.WriteTo([]byte(Fmt(`,"tx":[%v,{"inputs":[`, TxTypeBond)), w, n, err)
 	for i, in := range tx.Inputs {
 		in.WriteSignBytes(w, n, err)
-		if i != len(tx.Inputs) - 1 {
+		if i != len(tx.Inputs)-1 {
 			wire.WriteTo([]byte(","), w, n, err)
 		}
 	}
@@ -292,7 +292,7 @@ func (tx *BondTx) WriteSignBytes(chainID string, w io.Writer, n *int, err *error
 	wire.WriteTo([]byte(`,"unbond_to":[`), w, n, err)
 	for i, out := range tx.UnbondTo {
 		out.WriteSignBytes(w, n, err)
-		if i != len(tx.UnbondTo) - 1 {
+		if i != len(tx.UnbondTo)-1 {
 			wire.WriteTo([]byte(","), w, n, err)
 		}
 	}

--- a/txs/tx_test.go
+++ b/txs/tx_test.go
@@ -38,7 +38,10 @@ func TestSendTxSignable(t *testing.T) {
 			},
 		},
 	}
-	signBytes := acm.SignBytes(chainID, sendTx)
+	signBytes, err := acm.SignBytes(chainID, bondTx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[1,{"inputs":[{"address":"696E70757431","amount":12345,"sequence":67890},{"address":"696E70757432","amount":111,"sequence":222}],"outputs":[{"address":"6F757470757431","amount":333},{"address":"6F757470757432","amount":444}]}]}`,
 		chainID)
@@ -60,7 +63,10 @@ func TestCallTxSignable(t *testing.T) {
 		Fee:      222,
 		Data:     []byte("data1"),
 	}
-	signBytes := acm.SignBytes(chainID, callTx)
+	signBytes, err := acm.SignBytes(chainID, bondTx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[2,{"address":"636F6E747261637431","data":"6461746131","fee":222,"gas_limit":111,"input":{"address":"696E70757431","amount":12345,"sequence":67890}}]}`,
 		chainID)
@@ -80,7 +86,10 @@ func TestNameTxSignable(t *testing.T) {
 		Data: "secretly.not.google.com",
 		Fee:  1000,
 	}
-	signBytes := acm.SignBytes(chainID, nameTx)
+	signBytes, err := acm.SignBytes(chainID, bondTx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[3,{"data":"secretly.not.google.com","fee":1000,"input":{"address":"696E70757431","amount":12345,"sequence":250},"name":"google.com"}]}`,
 		chainID)
@@ -117,7 +126,10 @@ func TestBondTxSignable(t *testing.T) {
 			},
 		},
 	}
-	signBytes := acm.SignBytes(chainID, bondTx)
+	signBytes, err := acm.SignBytes(chainID, bondTx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[17,{"inputs":[{"address":"696E70757431","amount":12345,"sequence":67890},{"address":"696E70757432","amount":111,"sequence":222}],"pub_key":"3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29","unbond_to":[{"address":"6F757470757431","amount":333},{"address":"6F757470757432","amount":444}]}]}`,
 		chainID)
@@ -131,7 +143,10 @@ func TestUnbondTxSignable(t *testing.T) {
 		Address: []byte("address1"),
 		Height:  111,
 	}
-	signBytes := acm.SignBytes(chainID, unbondTx)
+	signBytes, err := acm.SignBytes(chainID, bondTx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[18,{"address":"6164647265737331","height":111}]}`,
 		chainID)
@@ -145,7 +160,10 @@ func TestRebondTxSignable(t *testing.T) {
 		Address: []byte("address1"),
 		Height:  111,
 	}
-	signBytes := acm.SignBytes(chainID, rebondTx)
+	signBytes, err := acm.SignBytes(chainID, bondTx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[19,{"address":"6164647265737331","height":111}]}`,
 		chainID)
@@ -168,7 +186,10 @@ func TestPermissionsTxSignable(t *testing.T) {
 		},
 	}
 
-	signBytes := acm.SignBytes(chainID, permsTx)
+	signBytes, err := acm.SignBytes(chainID, bondTx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[32,{"args":"[2,{"address":"6164647265737331","permission":1,"value":true}]","input":{"address":"696E70757431","amount":12345,"sequence":250}}]}`,
 		chainID)

--- a/txs/tx_test.go
+++ b/txs/tx_test.go
@@ -38,10 +38,7 @@ func TestSendTxSignable(t *testing.T) {
 			},
 		},
 	}
-	signBytes, err := acm.SignBytes(chainID, bondTx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signBytes := acm.SignBytes(chainID, sendTx)
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[1,{"inputs":[{"address":"696E70757431","amount":12345,"sequence":67890},{"address":"696E70757432","amount":111,"sequence":222}],"outputs":[{"address":"6F757470757431","amount":333},{"address":"6F757470757432","amount":444}]}]}`,
 		chainID)
@@ -63,10 +60,7 @@ func TestCallTxSignable(t *testing.T) {
 		Fee:      222,
 		Data:     []byte("data1"),
 	}
-	signBytes, err := acm.SignBytes(chainID, bondTx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signBytes := acm.SignBytes(chainID, callTx)
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[2,{"address":"636F6E747261637431","data":"6461746131","fee":222,"gas_limit":111,"input":{"address":"696E70757431","amount":12345,"sequence":67890}}]}`,
 		chainID)
@@ -86,10 +80,7 @@ func TestNameTxSignable(t *testing.T) {
 		Data: "secretly.not.google.com",
 		Fee:  1000,
 	}
-	signBytes, err := acm.SignBytes(chainID, bondTx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signBytes := acm.SignBytes(chainID, nameTx)
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[3,{"data":"secretly.not.google.com","fee":1000,"input":{"address":"696E70757431","amount":12345,"sequence":250},"name":"google.com"}]}`,
 		chainID)
@@ -126,10 +117,7 @@ func TestBondTxSignable(t *testing.T) {
 			},
 		},
 	}
-	signBytes, err := acm.SignBytes(chainID, bondTx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signBytes := acm.SignBytes(chainID, bondTx)
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[17,{"inputs":[{"address":"696E70757431","amount":12345,"sequence":67890},{"address":"696E70757432","amount":111,"sequence":222}],"pub_key":"3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29","unbond_to":[{"address":"6F757470757431","amount":333},{"address":"6F757470757432","amount":444}]}]}`,
 		chainID)
@@ -143,10 +131,7 @@ func TestUnbondTxSignable(t *testing.T) {
 		Address: []byte("address1"),
 		Height:  111,
 	}
-	signBytes, err := acm.SignBytes(chainID, bondTx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signBytes := acm.SignBytes(chainID, unbondTx)
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[18,{"address":"6164647265737331","height":111}]}`,
 		chainID)
@@ -160,10 +145,7 @@ func TestRebondTxSignable(t *testing.T) {
 		Address: []byte("address1"),
 		Height:  111,
 	}
-	signBytes, err := acm.SignBytes(chainID, bondTx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signBytes := acm.SignBytes(chainID, rebondTx)
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[19,{"address":"6164647265737331","height":111}]}`,
 		chainID)
@@ -186,10 +168,7 @@ func TestPermissionsTxSignable(t *testing.T) {
 		},
 	}
 
-	signBytes, err := acm.SignBytes(chainID, bondTx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signBytes := acm.SignBytes(chainID, permsTx)
 	signStr := string(signBytes)
 	expected := Fmt(`{"chain_id":"%s","tx":[32,{"args":"[2,{"address":"6164647265737331","permission":1,"value":true}]","input":{"address":"696E70757431","amount":12345,"sequence":250}}]}`,
 		chainID)


### PR DESCRIPTION
With a bit of related refactoring.

May substantive changes are `GenerateReceipt` and callers thereof. The receipt gets marshalled and unmarshalled from the data payload of the Tendermint response.

Closes #109 