### PR TITLE
Create fix

### DIFF
--- a/manager/eris-mint/state/execution.go
+++ b/manager/eris-mint/state/execution.go
@@ -513,7 +513,7 @@ func ExecTx(blockCache *BlockCache, tx txs.Tx, runCall bool, evc events.Fireable
 			// and only deduct from the caller's balance.
 			inAcc.Balance -= value
 			if createContract {
-				inAcc.Sequence += 1
+				inAcc.Sequence += 1 // XXX ?!
 			}
 			blockCache.UpdateAccount(inAcc)
 		}

--- a/manager/eris-mint/state/state_test.go
+++ b/manager/eris-mint/state/state_test.go
@@ -493,7 +493,6 @@ var callerCode, _ = hex.DecodeString("60606040526000357c010000000000000000000000
 var sendData, _ = hex.DecodeString("3e58c58c")
 
 func TestContractSend(t *testing.T) {
-	//evm.SetDebug(true)
 	state, privAccounts, _ := RandGenesisState(3, true, 1000, 1, true, 1000)
 
 	//val0 := state.GetValidatorInfo(privValidators[0].Address)

--- a/manager/eris-mint/state/tx_cache.go
+++ b/manager/eris-mint/state/tx_cache.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	acm "github.com/eris-ltd/eris-db/account"
 	"github.com/eris-ltd/eris-db/manager/eris-mint/evm"
 	ptypes "github.com/eris-ltd/eris-db/permission/types" // for GlobalPermissionAddress ...
@@ -65,6 +67,8 @@ func (cache *TxCache) CreateAccount(creator *vm.Account) *vm.Account {
 	nonce := creator.Nonce
 	creator.Nonce += 1
 
+	fmt.Printf("CREATE ACCOUNT %X %d\n", creator.Address.Bytes(), creator.Nonce)
+
 	addr := LeftPadWord256(NewContractAddress(creator.Address.Postfix(20), int(nonce)))
 
 	// Create account from address.
@@ -120,16 +124,19 @@ func (cache *TxCache) SetStorage(addr Word256, key Word256, value Word256) {
 // These updates do not have to be in deterministic order,
 // the backend is responsible for ordering updates.
 func (cache *TxCache) Sync() {
+	fmt.Println("SYNC")
 
 	// Remove or update storage
 	for addrKey, value := range cache.storages {
 		addr, key := Tuple256Split(addrKey)
+		fmt.Printf("UPDATE STORAGE %X %X %X\n", addr, key, value)
 		cache.backend.SetStorage(addr, key, value)
 	}
 
 	// Remove or update accounts
 	for addr, accInfo := range cache.accounts {
 		acc, removed := accInfo.unpack()
+		fmt.Printf("UPDATE ACC %X; removed %v\n", addr, removed)
 		if removed {
 			cache.backend.RemoveAccount(addr.Postfix(20))
 		} else {

--- a/manager/eris-mint/state/tx_cache.go
+++ b/manager/eris-mint/state/tx_cache.go
@@ -1,8 +1,6 @@
 package state
 
 import (
-	"fmt"
-
 	acm "github.com/eris-ltd/eris-db/account"
 	"github.com/eris-ltd/eris-db/manager/eris-mint/evm"
 	ptypes "github.com/eris-ltd/eris-db/permission/types" // for GlobalPermissionAddress ...
@@ -67,8 +65,6 @@ func (cache *TxCache) CreateAccount(creator *vm.Account) *vm.Account {
 	nonce := creator.Nonce
 	creator.Nonce += 1
 
-	fmt.Printf("CREATE ACCOUNT %X %d\n", creator.Address.Bytes(), creator.Nonce)
-
 	addr := LeftPadWord256(NewContractAddress(creator.Address.Postfix(20), int(nonce)))
 
 	// Create account from address.
@@ -124,19 +120,15 @@ func (cache *TxCache) SetStorage(addr Word256, key Word256, value Word256) {
 // These updates do not have to be in deterministic order,
 // the backend is responsible for ordering updates.
 func (cache *TxCache) Sync() {
-	fmt.Println("SYNC")
-
 	// Remove or update storage
 	for addrKey, value := range cache.storages {
 		addr, key := Tuple256Split(addrKey)
-		fmt.Printf("UPDATE STORAGE %X %X %X\n", addr, key, value)
 		cache.backend.SetStorage(addr, key, value)
 	}
 
 	// Remove or update accounts
 	for addr, accInfo := range cache.accounts {
 		acc, removed := accInfo.unpack()
-		fmt.Printf("UPDATE ACC %X; removed %v\n", addr, removed)
 		if removed {
 			cache.backend.RemoveAccount(addr.Postfix(20))
 		} else {


### PR DESCRIPTION
So this was actually pretty bad. Amazing that we never got it, probably because we never really cared about tokens. Basic "address.send()" from a contract [was broken](https://github.com/eris-ltd/eris-db/compare/create_fix?expand=1#diff-735ecc7ace7329b12bfb59eaa38f682bR495)! [This comment/contract](https://github.com/eris-ltd/eris-db/blob/develop/manager/eris-mint/evm/vm.go#L116) wasn't true, since we were [making calls without adding the account to the tx cache](https://github.com/eris-ltd/eris-db/blob/develop/manager/eris-mint/evm/vm.go#L814).

The new tests involve pre-compiled solidity contracts. It may be better to move them to epm, or to replace them with hand-written minimal byte code that captures the functionality.