### PR TITLE
Allow the RPC Subscribe method to see all events

### DIFF
--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -32,6 +32,7 @@ import (
 	tendermint_types "github.com/tendermint/tendermint/types"
 	tmsp_types "github.com/tendermint/tmsp/types"
 
+	edb_event "github.com/eris-ltd/eris-db/event"
 	log "github.com/eris-ltd/eris-logger"
 
 	config "github.com/eris-ltd/eris-db/config"
@@ -196,6 +197,10 @@ func (this *TendermintNode) PublicValidatorKey() crypto.PubKey {
 		copyPublicValidatorKey = nil
 	}
 	return copyPublicValidatorKey
+}
+
+func (this *TendermintNode) Events() edb_event.EventEmitter {
+	return edb_event.NewEvents(this.tmintNode.EventSwitch())
 }
 
 func (this *TendermintNode) BroadcastTransaction(transaction []byte,

--- a/definitions/consensus.go
+++ b/definitions/consensus.go
@@ -22,6 +22,7 @@ import (
 	tendermint_types "github.com/tendermint/tendermint/types"
 	tmsp_types "github.com/tendermint/tmsp/types"
 
+	edb_event "github.com/eris-ltd/eris-db/event"
 	rpc_tendermint_types "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
 )
 
@@ -46,6 +47,10 @@ type ConsensusEngine interface {
 	// Memory pool
 	BroadcastTransaction(transaction []byte,
 		callback func(*tmsp_types.Response)) error
+
+	// Events
+	// For consensus events like NewBlock
+	Events() edb_event.EventEmitter
 }
 
 // type Communicator interface {

--- a/event/event_cache.go
+++ b/event/event_cache.go
@@ -90,7 +90,7 @@ func (this *EventSubscriptions) Add(eventId string) (string, error) {
 		return "", errSID
 	}
 	cache := newEventCache()
-	_, errC := this.eventEmitter.Subscribe(subId, eventId,
+	errC := this.eventEmitter.Subscribe(subId, eventId,
 		func(evt evts.EventData) {
 			cache.mtx.Lock()
 			defer cache.mtx.Unlock()

--- a/event/event_cache.go
+++ b/event/event_cache.go
@@ -97,6 +97,8 @@ func (this *EventSubscriptions) Add(eventId string) (string, error) {
 			cache.events = append(cache.events, evt)
 		})
 	cache.subId = subId
+	this.mtx.Lock()
+	defer this.mtx.Unlock()
 	this.subs[subId] = cache
 	if errC != nil {
 		return "", errC

--- a/event/events.go
+++ b/event/events.go
@@ -38,6 +38,9 @@ func NewEvents(eventSwitch *evts.EventSwitch) *events {
 	return &events{eventSwitch}
 }
 
+// Provides an EventEmitter that wraps many underlying EventEmitters as a
+// convenience for Subscribing and Unsubscribing on multiple EventEmitters at
+// once
 func Multiplex(events ...EventEmitter) *multiplexedEvents {
 	return &multiplexedEvents{events}
 }

--- a/event/events_test.go
+++ b/event/events_test.go
@@ -1,0 +1,60 @@
+package event
+
+import (
+	"testing"
+
+	"sync"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	evts "github.com/tendermint/go-events"
+)
+
+func TestMultiplexedEvents(t *testing.T) {
+	emitter1 := newMockEventEmitter()
+	emitter2 := newMockEventEmitter()
+	emitter12 := Multiplex(emitter1, emitter2)
+
+	eventData1 := make(map[evts.EventData]int)
+	eventData2 := make(map[evts.EventData]int)
+	eventData12 := make(map[evts.EventData]int)
+
+	mutex1 := &sync.Mutex{}
+	mutex2 := &sync.Mutex{}
+	mutex12 := &sync.Mutex{}
+
+	emitter12.Subscribe("Sub12", "Event12", func(eventData evts.EventData) {
+		mutex12.Lock()
+		eventData12[eventData] = 1
+		mutex12.Unlock()
+	})
+	emitter1.Subscribe("Sub1", "Event1", func(eventData evts.EventData) {
+		mutex1.Lock()
+		eventData1[eventData] = 1
+		mutex1.Unlock()
+	})
+	emitter2.Subscribe("Sub2", "Event2", func(eventData evts.EventData) {
+		mutex2.Lock()
+		eventData2[eventData] = 1
+		mutex2.Unlock()
+	})
+
+	time.Sleep(mockInterval)
+
+	allEventData := make(map[evts.EventData]int)
+	for k, v := range eventData1 {
+		allEventData[k] = v
+	}
+	for k, v := range eventData2 {
+		allEventData[k] = v
+	}
+
+	assert.Equal(t, map[evts.EventData]int{mockEventData{"Sub1", "Event1"}: 1},
+		eventData1)
+	assert.Equal(t, map[evts.EventData]int{mockEventData{"Sub2", "Event2"}: 1},
+		eventData2)
+	assert.Equal(t, map[evts.EventData]int{mockEventData{"Sub12", "Event12"}: 1},
+		eventData12)
+
+	assert.NotEmpty(t, allEventData, "Some events should have been published")
+}

--- a/rpc/tendermint/client/client.go
+++ b/rpc/tendermint/client/client.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	acm "github.com/eris-ltd/eris-db/account"
 	core_types "github.com/eris-ltd/eris-db/core/types"
 	rpc_types "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"

--- a/rpc/tendermint/client/client.go
+++ b/rpc/tendermint/client/client.go
@@ -98,7 +98,6 @@ func BroadcastTx(client rpcclient.Client,
 	receiptBytes := res.(*rpc_types.ResultBroadcastTx).Data
 	receipt := txs.Receipt{}
 	err = wire.ReadBinaryBytes(receiptBytes, &receipt)
-	fmt.Printf("rec: %#v\n", receipt)
 	return receipt, err
 
 }

--- a/rpc/tendermint/test/common.go
+++ b/rpc/tendermint/test/common.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"github.com/eris-ltd/eris-db/test/fixtures"
 	"testing"
 )

--- a/rpc/tendermint/test/common.go
+++ b/rpc/tendermint/test/common.go
@@ -17,11 +17,7 @@ func TestWrapper(runner func() int) int {
 		panic(err)
 	}
 
-	saveNewPriv()
-
 	// start a node
-
-	fmt.Println()
 	ready := make(chan error)
 	go newNode(ready)
 	err = <-ready

--- a/rpc/tendermint/test/shared.go
+++ b/rpc/tendermint/test/shared.go
@@ -75,6 +75,9 @@ func initGlobalVariables(ffs *fixtures.FileFixtures) error {
 		return err
 	}
 
+	// Set up priv_validator.json before we start tendermint (otherwise it will
+	// create its own one.
+	saveNewPriv()
 	testCore, err = core.NewCore("testCore", consensusConfig, managerConfig)
 	if err != nil {
 		return err
@@ -100,15 +103,21 @@ func makeUsers(n int) []*acm.PrivAccount {
 
 // create a new node and sleep forever
 func newNode(ready chan error) {
-	// Run the RPC server.
-	_, err := testCore.NewGatewayTendermint(config)
-	ready <- err
-
-	// Sleep forever
-	if err == nil {
-		//ch := make(chan struct{})
-		//<-ch
+	// TODO: we don't need to start a V0 gateway this was added for debugging, remove
+	serverProcess, err := testCore.NewGatewayV0(config)
+	if err != nil {
+		ready <- err
 	}
+
+	err = serverProcess.Start()
+	if err != nil {
+		ready <- err
+	}
+
+	// Run the RPC servers
+	_, err = testCore.NewGatewayTendermint(config)
+	ready <- err
+	<-serverProcess.StopEventChannel()
 }
 
 func saveNewPriv() {

--- a/rpc/tendermint/test/ws_helpers.go
+++ b/rpc/tendermint/test/ws_helpers.go
@@ -17,6 +17,10 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
+const (
+	timeoutSeconds = 5
+)
+
 //--------------------------------------------------------------------------------
 // Utilities for testing the websocket service
 
@@ -81,7 +85,7 @@ func waitForEvent(t *testing.T, wsc *client.WSClient, eventid string, dieOnTimeo
 	f()
 
 	// wait for an event or timeout
-	timeout := time.NewTimer(10 * time.Second)
+	timeout := time.NewTimer(timeoutSeconds * time.Second)
 	select {
 	case <-timeout.C:
 		if dieOnTimeout {

--- a/rpc/v0/json_service.go
+++ b/rpc/v0/json_service.go
@@ -164,11 +164,11 @@ func (this *ErisDbJsonService) EventUnsubscribe(request *rpc.RPCRequest,
 	}
 	subId := param.SubId
 
-	result, errC := this.pipe.Events().Unsubscribe(subId)
+	errC := this.pipe.Events().Unsubscribe(subId)
 	if errC != nil {
 		return nil, rpc.INTERNAL_ERROR, errC
 	}
-	return &event.EventUnsub{result}, 0, nil
+	return &event.EventUnsub{true}, 0, nil
 }
 
 // Check subscription event cache for new data.

--- a/rpc/v0/wsService.go
+++ b/rpc/v0/wsService.go
@@ -112,7 +112,7 @@ func (this *ErisDbWsService) EventSubscribe(request *rpc.RPCRequest, requester i
 	callback := func(ret events.EventData) {
 		this.writeResponse(subId, ret, session)
 	}
-	_, errC := this.pipe.Events().Subscribe(subId, eventId, callback)
+	errC := this.pipe.Events().Subscribe(subId, eventId, callback)
 	if errC != nil {
 		return nil, rpc.INTERNAL_ERROR, errC
 	}
@@ -127,11 +127,11 @@ func (this *ErisDbWsService) EventUnsubscribe(request *rpc.RPCRequest, requester
 	}
 	eventId := param.EventId
 
-	result, errC := this.pipe.Events().Unsubscribe(eventId)
+	errC := this.pipe.Events().Unsubscribe(eventId)
 	if errC != nil {
 		return nil, rpc.INTERNAL_ERROR, errC
 	}
-	return &event.EventUnsub{result}, 0, nil
+	return &event.EventUnsub{true}, 0, nil
 }
 
 func (this *ErisDbWsService) EventPoll(request *rpc.RPCRequest, requester interface{}) (interface{}, int, error) {

--- a/test/mock/pipe.go
+++ b/test/mock/pipe.go
@@ -182,12 +182,12 @@ type eventer struct {
 	testData *td.TestData
 }
 
-func (this *eventer) Subscribe(subId, event string, callback func(evts.EventData)) (bool, error) {
-	return true, nil
+func (this *eventer) Subscribe(subId, event string, callback func(evts.EventData)) error {
+	return nil
 }
 
-func (this *eventer) Unsubscribe(subId string) (bool, error) {
-	return true, nil
+func (this *eventer) Unsubscribe(subId string) error {
+	return nil
 }
 
 // NameReg


### PR DESCRIPTION
Those events from both consensus and application manager.

Doesn't fix tests. Because Ben.

Sorry, I have caught some bullshit formatting changes here.

manager/eris-mint/pipe.go is the real entry point here