### PR TITLE
Adding some debug output fixes issue with TestHTTPGetStorage [DO NOT MERGE]

### DIFF
--- a/rpc/tendermint/test/shared.go
+++ b/rpc/tendermint/test/shared.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 	tm_common "github.com/tendermint/go-common"
 	"github.com/tendermint/tendermint/types"
+	"fmt"
 )
 
 // global variables for use across all tests
@@ -228,6 +229,13 @@ func dumpStorage(t *testing.T, addr []byte) *rpc_types.ResultDumpStorage {
 
 func getStorage(t *testing.T, typ string, addr, key []byte) []byte {
 	client := clients[typ]
+	var res rpc_types.ErisDBResult
+	client.(*rpcclient.ClientJSONRPC).Call("list_accounts", []interface{}{}, &res)
+	fmt.Printf("MARMOT, list_accounts: %#v \n", res)
+	list := res.(*rpc_types.ResultListAccounts)
+	for _, account := range list.Accounts {
+		fmt.Printf("MARMOT: %#v\n", account.String())
+	}
 	resp, err := edbcli.GetStorage(client, addr, key)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Looking at the RPC test TestHTTPGetStorage, runnable with:

`go test -v ./rpc/tendermint/test -run TestHTTPGetStorage`

The test fails on the current develop branch with:

```
--- FAIL: TestHTTPGetStorage (0.94s)
	shared.go:233: UnknownAddress: 49EA30FCAE731BDE36742F85901549F515EA1A32
FAIL
```

Adding a bit of MARMOT debug, contained in this PR, which was only intended to provide some insight into the Accounts that are defined on the chain then 'fixes' the issue. So we have a Heisenbug. Clearly there is something a bit interesting going on here.

I will look into the cause off the original error some more, and then try to understand why what should be an unrelated read operation makes it go away.