### PR TITLE
Remove redundant v0 gateway from tendermint tests

### DIFF
--- a/rpc/tendermint/test/shared.go
+++ b/rpc/tendermint/test/shared.go
@@ -104,21 +104,9 @@ func makeUsers(n int) []*acm.PrivAccount {
 
 // create a new node and sleep forever
 func newNode(ready chan error) {
-	// TODO: we don't need to start a V0 gateway this was added for debugging, remove
-	serverProcess, err := testCore.NewGatewayV0(config)
-	if err != nil {
-		ready <- err
-	}
-
-	err = serverProcess.Start()
-	if err != nil {
-		ready <- err
-	}
-
 	// Run the RPC servers
-	_, err = testCore.NewGatewayTendermint(config)
+	_, err := testCore.NewGatewayTendermint(config)
 	ready <- err
-	<-serverProcess.StopEventChannel()
 }
 
 func saveNewPriv() {


### PR DESCRIPTION
Meant to remove this in a previous PR