### PR TITLE
Combine consensus and manager events into a pool of types we control

### DIFF
--- a/event/event_cache.go
+++ b/event/event_cache.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	evts "github.com/tendermint/go-events"
+	"github.com/eris-ltd/eris-db/txs"
 )
 
 var (
@@ -91,7 +90,7 @@ func (this *EventSubscriptions) Add(eventId string) (string, error) {
 	}
 	cache := newEventCache()
 	errC := this.eventEmitter.Subscribe(subId, eventId,
-		func(evt evts.EventData) {
+		func(evt txs.EventData) {
 			cache.mtx.Lock()
 			defer cache.mtx.Unlock()
 			cache.events = append(cache.events, evt)

--- a/event/event_cache_test.go
+++ b/event/event_cache_test.go
@@ -9,8 +9,8 @@ import (
 
 	"sync"
 
+	"github.com/eris-ltd/eris-db/txs"
 	"github.com/stretchr/testify/assert"
-	evts "github.com/tendermint/go-events"
 )
 
 var mockInterval = 10 * time.Millisecond
@@ -18,7 +18,7 @@ var mockInterval = 10 * time.Millisecond
 type mockSub struct {
 	subId    string
 	eventId  string
-	f        func(evts.EventData)
+	f        func(txs.EventData)
 	shutdown bool
 	sdChan   chan struct{}
 }
@@ -29,7 +29,7 @@ type mockEventData struct {
 }
 
 // A mock event
-func newMockSub(subId, eventId string, f func(evts.EventData)) mockSub {
+func newMockSub(subId, eventId string, f func(txs.EventData)) mockSub {
 	return mockSub{subId, eventId, f, false, make(chan struct{})}
 }
 
@@ -42,7 +42,7 @@ func newMockEventEmitter() *mockEventEmitter {
 	return &mockEventEmitter{make(map[string]mockSub), &sync.Mutex{}}
 }
 
-func (this *mockEventEmitter) Subscribe(subId, eventId string, callback func(evts.EventData)) error {
+func (this *mockEventEmitter) Subscribe(subId, eventId string, callback func(txs.EventData)) error {
 	if _, ok := this.subs[subId]; ok {
 		return nil
 	}

--- a/event/events_test.go
+++ b/event/events_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	evts "github.com/tendermint/go-events"
+	"github.com/eris-ltd/eris-db/txs"
 )
 
 func TestMultiplexedEvents(t *testing.T) {
@@ -15,25 +16,25 @@ func TestMultiplexedEvents(t *testing.T) {
 	emitter2 := newMockEventEmitter()
 	emitter12 := Multiplex(emitter1, emitter2)
 
-	eventData1 := make(map[evts.EventData]int)
-	eventData2 := make(map[evts.EventData]int)
-	eventData12 := make(map[evts.EventData]int)
+	eventData1 := make(map[txs.EventData]int)
+	eventData2 := make(map[txs.EventData]int)
+	eventData12 := make(map[txs.EventData]int)
 
 	mutex1 := &sync.Mutex{}
 	mutex2 := &sync.Mutex{}
 	mutex12 := &sync.Mutex{}
 
-	emitter12.Subscribe("Sub12", "Event12", func(eventData evts.EventData) {
+	emitter12.Subscribe("Sub12", "Event12", func(eventData txs.EventData) {
 		mutex12.Lock()
 		eventData12[eventData] = 1
 		mutex12.Unlock()
 	})
-	emitter1.Subscribe("Sub1", "Event1", func(eventData evts.EventData) {
+	emitter1.Subscribe("Sub1", "Event1", func(eventData txs.EventData) {
 		mutex1.Lock()
 		eventData1[eventData] = 1
 		mutex1.Unlock()
 	})
-	emitter2.Subscribe("Sub2", "Event2", func(eventData evts.EventData) {
+	emitter2.Subscribe("Sub2", "Event2", func(eventData txs.EventData) {
 		mutex2.Lock()
 		eventData2[eventData] = 1
 		mutex2.Unlock()
@@ -41,7 +42,7 @@ func TestMultiplexedEvents(t *testing.T) {
 
 	time.Sleep(mockInterval)
 
-	allEventData := make(map[evts.EventData]int)
+	allEventData := make(map[txs.EventData]int)
 	for k, v := range eventData1 {
 		allEventData[k] = v
 	}
@@ -49,11 +50,11 @@ func TestMultiplexedEvents(t *testing.T) {
 		allEventData[k] = v
 	}
 
-	assert.Equal(t, map[evts.EventData]int{mockEventData{"Sub1", "Event1"}: 1},
+	assert.Equal(t, map[txs.EventData]int{mockEventData{"Sub1", "Event1"}: 1},
 		eventData1)
-	assert.Equal(t, map[evts.EventData]int{mockEventData{"Sub2", "Event2"}: 1},
+	assert.Equal(t, map[txs.EventData]int{mockEventData{"Sub2", "Event2"}: 1},
 		eventData2)
-	assert.Equal(t, map[evts.EventData]int{mockEventData{"Sub12", "Event12"}: 1},
+	assert.Equal(t, map[txs.EventData]int{mockEventData{"Sub12", "Event12"}: 1},
 		eventData12)
 
 	assert.NotEmpty(t, allEventData, "Some events should have been published")

--- a/manager/eris-mint/eris-mint.go
+++ b/manager/eris-mint/eris-mint.go
@@ -138,8 +138,6 @@ func (app *ErisMint) AppendTx(txBytes []byte) (res tmsp.Result) {
 		return tmsp.NewError(tmsp.CodeType_EncodingError, fmt.Sprintf("Encoding error: %v", err))
 	}
 
-	log.Info("AppendTx", "tx", *tx)
-
 	err = sm.ExecTx(app.cache, *tx, true, app.evc)
 	if err != nil {
 		return tmsp.NewError(tmsp.CodeType_InternalError, fmt.Sprintf("Internal error: %v", err))

--- a/manager/eris-mint/pipe.go
+++ b/manager/eris-mint/pipe.go
@@ -236,10 +236,11 @@ func (pipe *erisMintPipe) Subscribe(listenerId, event string,
 	rpcResponseWriter func(result rpc_tm_types.ErisDBResult)) (*rpc_tm_types.ResultSubscribe, error) {
 	log.WithFields(log.Fields{"listenerId": listenerId, "event": event}).
 		Info("Subscribing to event")
+
 	pipe.consensusAndManagerEvents().Subscribe(subscriptionId(listenerId, event), event,
-		func(eventData go_events.EventData) {
+		func(eventData txs.EventData) {
 			result := rpc_tm_types.ErisDBResult(&rpc_tm_types.ResultEvent{event,
-				tm_types.TMEventData(eventData)})
+				txs.EventData(eventData)})
 			// NOTE: EventSwitch callbacks must be nonblocking
 			rpcResponseWriter(result)
 		})

--- a/manager/eris-mint/transactor.go
+++ b/manager/eris-mint/transactor.go
@@ -207,12 +207,13 @@ func (this *transactor) TransactAndHold(privKey, address, data []byte, gasLimit,
 	}
 	wc := make(chan *txs.EventDataCall)
 	subId := fmt.Sprintf("%X", rec.TxHash)
-	this.eventEmitter.Subscribe(subId, txs.EventStringAccCall(addr), func(evt tEvents.EventData) {
-		event := evt.(txs.EventDataCall)
-		if bytes.Equal(event.TxID, rec.TxHash) {
-			wc <- &event
-		}
-	})
+	this.eventEmitter.Subscribe(subId, txs.EventStringAccCall(addr),
+		func(evt txs.EventData) {
+			event := evt.(txs.EventDataCall)
+			if bytes.Equal(event.TxID, rec.TxHash) {
+				wc <- &event
+			}
+		})
 
 	timer := time.NewTimer(300 * time.Second)
 	toChan := timer.C

--- a/rpc/tendermint/core/types/responses.go
+++ b/rpc/tendermint/core/types/responses.go
@@ -124,8 +124,8 @@ type ResultSignTx struct {
 }
 
 type ResultEvent struct {
-	Event string            `json:"event"`
-	Data  types.TMEventData `json:"data"`
+	Event string        `json:"event"`
+	Data  txs.EventData `json:"data"`
 }
 
 //----------------------------------------

--- a/rpc/tendermint/test/client_ws_test.go
+++ b/rpc/tendermint/test/client_ws_test.go
@@ -28,10 +28,11 @@ func TestWSNewBlock(t *testing.T) {
 		unsubscribe(t, wsc, eid)
 		wsc.Stop()
 	}()
-	waitForEvent(t, wsc, eid, true, func() {}, func(eid string, b interface{}) error {
-		fmt.Println("Check:", string(b.([]byte)))
-		return nil
-	})
+	waitForEvent(t, wsc, eid, true, func() {},
+		func(eid string, b interface{}) error {
+			fmt.Println("Check:", string(b.([]byte)))
+			return nil
+		})
 }
 
 // receive a few new block messages in a row, with increasing height

--- a/rpc/tendermint/test/common.go
+++ b/rpc/tendermint/test/common.go
@@ -32,7 +32,7 @@ func TestWrapper(runner func() int) int {
 func DebugMain() {
 	t := &testing.T{}
 	TestWrapper(func() int {
-		testBroadcastTx(t, "HTTP")
+		testNameReg(t, "JSONRPC")
 		return 0
 	})
 }

--- a/rpc/tendermint/test/common.go
+++ b/rpc/tendermint/test/common.go
@@ -29,6 +29,11 @@ func TestWrapper(runner func() int) int {
 	return runner()
 }
 
+// This main function exists as a little convenience mechanism for running the
+// delve debugger which doesn't work well from go test yet. In due course it can
+// be removed, but it's flux between pull requests should be considered
+// inconsequential, so feel free to insert your own code if you want to use it
+// as an application entry point for delve debugging.
 func DebugMain() {
 	t := &testing.T{}
 	TestWrapper(func() int {

--- a/rpc/tendermint/test/shared.go
+++ b/rpc/tendermint/test/shared.go
@@ -102,9 +102,8 @@ func makeUsers(n int) []*acm.PrivAccount {
 	return accounts
 }
 
-// create a new node and sleep forever
 func newNode(ready chan error) {
-	// Run the RPC servers
+	// Run the 'tendermint' rpc server
 	_, err := testCore.NewGatewayTendermint(config)
 	ready <- err
 }

--- a/rpc/tendermint/test/ws_helpers.go
+++ b/rpc/tendermint/test/ws_helpers.go
@@ -49,7 +49,8 @@ func unsubscribe(t *testing.T, wsc *client.WSClient, eventid string) {
 
 // wait for an event; do things that might trigger events, and check them when they are received
 // the check function takes an event id and the byte slice read off the ws
-func waitForEvent(t *testing.T, wsc *client.WSClient, eventid string, dieOnTimeout bool, f func(), check func(string, interface{}) error) {
+func waitForEvent(t *testing.T, wsc *client.WSClient, eventid string,
+	dieOnTimeout bool, f func(), check func(string, interface{}) error) {
 	// go routine to wait for webscoket msg
 	goodCh := make(chan interface{})
 	errCh := make(chan error)

--- a/test/mock/pipe.go
+++ b/test/mock/pipe.go
@@ -10,9 +10,8 @@ import (
 
 	manager_types "github.com/eris-ltd/eris-db/manager/types"
 	td "github.com/eris-ltd/eris-db/test/testdata/testdata"
-	types "github.com/eris-ltd/eris-db/txs"
+	"github.com/eris-ltd/eris-db/txs"
 
-	evts "github.com/tendermint/go-events"
 	mintTypes "github.com/tendermint/tendermint/types"
 )
 
@@ -182,7 +181,7 @@ type eventer struct {
 	testData *td.TestData
 }
 
-func (this *eventer) Subscribe(subId, event string, callback func(evts.EventData)) error {
+func (this *eventer) Subscribe(subId, event string, callback func(txs.EventData)) error {
 	return nil
 }
 
@@ -250,37 +249,37 @@ func (this *transactor) CallCode(from, code, data []byte) (*core_types.Call, err
 	return this.testData.CallCode.Output, nil
 }
 
-func (this *transactor) BroadcastTx(tx types.Tx) (*types.Receipt, error) {
+func (this *transactor) BroadcastTx(tx txs.Tx) (*txs.Receipt, error) {
 	return nil, nil
 }
 
-func (this *transactor) UnconfirmedTxs() (*types.UnconfirmedTxs, error) {
+func (this *transactor) UnconfirmedTxs() (*txs.UnconfirmedTxs, error) {
 	return this.testData.GetUnconfirmedTxs.Output, nil
 }
 
-func (this *transactor) Transact(privKey, address, data []byte, gasLimit, fee int64) (*types.Receipt, error) {
+func (this *transactor) Transact(privKey, address, data []byte, gasLimit, fee int64) (*txs.Receipt, error) {
 	if address == nil || len(address) == 0 {
 		return this.testData.TransactCreate.Output, nil
 	}
 	return this.testData.Transact.Output, nil
 }
 
-func (this *transactor) TransactAndHold(privKey, address, data []byte, gasLimit, fee int64) (*types.EventDataCall, error) {
+func (this *transactor) TransactAndHold(privKey, address, data []byte, gasLimit, fee int64) (*txs.EventDataCall, error) {
 	return nil, nil
 }
 
-func (this *transactor) Send(privKey, toAddress []byte, amount int64) (*types.Receipt, error) {
+func (this *transactor) Send(privKey, toAddress []byte, amount int64) (*txs.Receipt, error) {
 	return nil, nil
 }
 
-func (this *transactor) SendAndHold(privKey, toAddress []byte, amount int64) (*types.Receipt, error) {
+func (this *transactor) SendAndHold(privKey, toAddress []byte, amount int64) (*txs.Receipt, error) {
 	return nil, nil
 }
 
-func (this *transactor) TransactNameReg(privKey []byte, name, data string, amount, fee int64) (*types.Receipt, error) {
+func (this *transactor) TransactNameReg(privKey []byte, name, data string, amount, fee int64) (*txs.Receipt, error) {
 	return this.testData.TransactNameReg.Output, nil
 }
 
-func (this *transactor) SignTx(tx types.Tx, privAccounts []*account.PrivAccount) (types.Tx, error) {
+func (this *transactor) SignTx(tx txs.Tx, privAccounts []*account.PrivAccount) (txs.Tx, error) {
 	return nil, nil
 }

--- a/txs/events.go
+++ b/txs/events.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/tendermint/go-common"
 	"github.com/tendermint/go-wire"
 
-	"github.com/tendermint/tendermint/types" // Block
+	tm_types "github.com/tendermint/tendermint/types" // Block
 )
 
 // Functions to generate eventId strings
@@ -43,9 +43,11 @@ const (
 	EventDataTypeTx       = byte(0x03)
 	EventDataTypeCall     = byte(0x04)
 	EventDataTypeLog      = byte(0x05)
+	EventDataTypeNewBlockHeader = byte(0x06)
 
 	EventDataTypeRoundState = byte(0x11)
 	EventDataTypeVote       = byte(0x12)
+
 )
 
 type EventData interface {
@@ -54,6 +56,7 @@ type EventData interface {
 
 var _ = wire.RegisterInterface(
 	struct{ EventData }{},
+	wire.ConcreteType{EventDataNewBlockHeader{}, EventDataTypeNewBlockHeader},
 	wire.ConcreteType{EventDataNewBlock{}, EventDataTypeNewBlock},
 	// wire.ConcreteType{EventDataFork{}, EventDataTypeFork },
 	wire.ConcreteType{EventDataTx{}, EventDataTypeTx},
@@ -67,7 +70,11 @@ var _ = wire.RegisterInterface(
 // but some (an input to a call tx or a receive) are more exotic
 
 type EventDataNewBlock struct {
-	Block *types.Block `json:"block"`
+	Block *tm_types.Block `json:"block"`
+}
+
+type EventDataNewBlockHeader struct {
+	Header *tm_types.Header `json:"header"`
 }
 
 // All txs fire EventDataTx, but only CallTx might have Return or Exception
@@ -107,27 +114,28 @@ type EventDataLog struct {
 type EventDataRoundState struct {
 	CurrentTime time.Time `json:"current_time"`
 
-	Height        int             `json:"height"`
-	Round         int             `json:"round"`
-	Step          string          `json:"step"`
-	StartTime     time.Time       `json:"start_time"`
-	CommitTime    time.Time       `json:"commit_time"`
-	Proposal      *types.Proposal `json:"proposal"`
-	ProposalBlock *types.Block    `json:"proposal_block"`
-	LockedRound   int             `json:"locked_round"`
-	LockedBlock   *types.Block    `json:"locked_block"`
-	POLRound      int             `json:"pol_round"`
+	Height        int                `json:"height"`
+	Round         int                `json:"round"`
+	Step          string             `json:"step"`
+	StartTime     time.Time          `json:"start_time"`
+	CommitTime    time.Time          `json:"commit_time"`
+	Proposal      *tm_types.Proposal `json:"proposal"`
+	ProposalBlock *tm_types.Block    `json:"proposal_block"`
+	LockedRound   int                `json:"locked_round"`
+	LockedBlock   *tm_types.Block    `json:"locked_block"`
+	POLRound      int                `json:"pol_round"`
 }
 
 type EventDataVote struct {
 	Index   int
 	Address []byte
-	Vote    *types.Vote
+	Vote    *tm_types.Vote
 }
 
-func (_ EventDataNewBlock) AssertIsEventData()   {}
-func (_ EventDataTx) AssertIsEventData()         {}
-func (_ EventDataCall) AssertIsEventData()       {}
-func (_ EventDataLog) AssertIsEventData()        {}
-func (_ EventDataRoundState) AssertIsEventData() {}
-func (_ EventDataVote) AssertIsEventData()       {}
+func (_ EventDataNewBlock) AssertIsEventData()       {}
+func (_ EventDataNewBlockHeader) AssertIsEventData() {}
+func (_ EventDataTx) AssertIsEventData()             {}
+func (_ EventDataCall) AssertIsEventData()           {}
+func (_ EventDataLog) AssertIsEventData()            {}
+func (_ EventDataRoundState) AssertIsEventData()     {}
+func (_ EventDataVote) AssertIsEventData()           {}


### PR DESCRIPTION
The approach here is to deal with underlying go-events EventData that is a generic marker interface by mapping it to our our own EventData types, which is a marker interface with an assertion method. This is in the spirit of the refactor to take control of the types we depend on. Ultimately we still care about some tendermint types but we are reducing the surface area of the dependency.

This resolves some issues with subscription, which exposes some other issues that we will fix with a subsequent PR.