### PR TITLE
Don't special case empty blocks when refreshing the checkCache on commit

### DIFF
--- a/manager/eris-mint/eris-mint.go
+++ b/manager/eris-mint/eris-mint.go
@@ -185,14 +185,11 @@ func (app *ErisMint) Commit() (res tmsp.Result) {
 	// sync the AppendTx cache
 	app.cache.Sync()
 
-	// if there were any txs in the block,
-	// reset the check cache to the new height
-	if app.nTxs > 0 {
-		log.WithFields(log.Fields{
-			"txs": app.nTxs,
-		}).Info("Reset checkCache")
-		app.checkCache = sm.NewBlockCache(app.state)
-	}
+	// Refresh the checkCache with the latest commited state
+	log.WithFields(log.Fields{
+		"txs": app.nTxs,
+	}).Info("Reset checkCache")
+	app.checkCache = sm.NewBlockCache(app.state)
 	app.nTxs = 0
 
 	// save state to disk


### PR DESCRIPTION
There are more profound related considerations detailed in #228. But independent of those I think this simple change is a win for clarity and the principle of honouring the most recent committed state.

Only refreshing the checkCache on non-empty blocks can be seen as an optimisation that it turns out is on shaking grounds: namely assuming that the committing of an empty block implies that the checkCache is clean. This may have been true at one point, but no longer is in general.

This change also fixes an actual real life bug in the reprocessing of an identical transaction in the mempool that is encountered in integration tests.