### PR TITLE
version: correct develop to v0.12.0-rc3

### DIFF
--- a/consensus/tendermint/version.go
+++ b/consensus/tendermint/version.go
@@ -17,6 +17,10 @@
 package tendermint
 
 import (
+	"strconv"
+
+	tendermint_version "github.com/tendermint/tendermint/version"
+
 	version "github.com/eris-ltd/eris-db/version"
 )
 
@@ -24,14 +28,51 @@ const (
 	// Client identifier to advertise over the network
 	tendermintClientIdentifier = "tendermint"
 	// Major version component of the current release
-	tendermintVersionMajor = 0
+	tendermintVersionMajorConst uint8 = 0
 	// Minor version component of the current release
-	tendermintVersionMinor = 6
+	tendermintVersionMinorConst uint8 = 6
 	// Patch version component of the current release
-	tendermintVersionPatch = 0
+	tendermintVersionPatchConst uint8 = 0
 )
+
+var (
+	tendermintVersionMajor uint8
+	tendermintVersionMinor uint8
+	tendermintVersionPatch uint8
+)
+
+func init() {
+	// discard error because we test for this in Continuous Integration tests
+	tendermintVersionMajor, _ = getTendermintMajorVersionFromSource()
+	tendermintVersionMinor, _ = getTendermintMinorVersionFromSource()
+	tendermintVersionPatch, _ = getTendermintPatchVersionFromSource()
+}
 
 func GetTendermintVersion() *version.VersionIdentifier {
 	return version.New(tendermintClientIdentifier, tendermintVersionMajor,
 		tendermintVersionMinor, tendermintVersionPatch)
+}
+
+func getTendermintMajorVersionFromSource() (uint8, error) {
+	majorVersionUint, err := strconv.ParseUint(tendermint_version.Maj, 10, 8)
+	if err != nil {
+		return tendermintVersionMajorConst, err
+	}
+	return uint8(majorVersionUint), nil
+}
+
+func getTendermintMinorVersionFromSource() (uint8, error) {
+	minorVersionUint, err := strconv.ParseUint(tendermint_version.Min, 10, 8)
+	if err != nil {
+		return tendermintVersionMinorConst, err
+	}
+	return uint8(minorVersionUint), nil
+}
+
+func getTendermintPatchVersionFromSource() (uint8, error) {
+	patchVersionUint, err := strconv.ParseUint(tendermint_version.Fix, 10, 8)
+	if err != nil {
+		return tendermintVersionPatchConst, err
+	}
+	return uint8(patchVersionUint), nil
 }

--- a/consensus/tendermint/version_test.go
+++ b/consensus/tendermint/version_test.go
@@ -1,0 +1,58 @@
+// Copyright 2015, 2016 Eris Industries (UK) Ltd.
+// This file is part of Eris-RT
+
+// Eris-RT is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Eris-RT is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Eris-RT.  If not, see <http://www.gnu.org/licenses/>.
+
+package tendermint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinorVersionTendermintEqual(t *testing.T) {
+	// assert explicitly on major and minor version number
+	assert.Equal(t, tendermintVersionMajorConst, tendermintVersionMajor,
+		fmt.Sprintf("Major version number for Tendermint consensus is not %v as expected: %v",
+		tendermintVersionMajorConst, tendermintVersionMajor))
+	assert.Equal(t, tendermintVersionMinorConst, tendermintVersionMinor,
+		fmt.Sprintf("Minor version number for Tendermint consensus is not %v as expected: %v",
+		tendermintVersionMinorConst, tendermintVersionMinor))
+	// assert patch number can not regress
+	if tendermintVersionPatchConst > tendermintVersionPatch {
+		t.Errorf("Patch version has regressed for Tendermint consensus: expected minimally %v, got %v",
+			tendermintVersionPatchConst, tendermintVersionPatch)
+		t.Fail()
+	}
+}
+
+func TestSemanticVersioningTendermint(t *testing.T) {
+	// assert that reading the semantic version from Tendermint vendored source
+	// succeeds without error; at runtime initialisation, on error we default
+	// to hard-coded semantic version
+	if _, err := getTendermintMajorVersionFromSource(); err != nil {
+		t.Errorf("Failed to read Major version from Tendermint source code: %s", err)
+		t.Fail()
+	}
+	if _, err := getTendermintMinorVersionFromSource(); err != nil {
+		t.Errorf("Failed to read Minor version from Tendermint source code: %s", err)
+		t.Fail()
+	}
+	if _, err := getTendermintPatchVersionFromSource(); err != nil {
+		t.Errorf("Failed to read Patch version from Tendermint source code: %s", err)
+		t.Fail()
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -125,11 +125,8 @@ func (version *VersionIdentifier) MatchesMinorVersion(
 }
 
 //------------------------------------------------------------------------------
-// Version number for DOCKER/build.sh
-
-// NOTE [ben]: deprecate public const version string
-const TENDERMINT_VERSION = "0.5.0"
+// Version number for tests/build_tool.sh
 
 // IMPORTANT: Eris-DB version must be on the last line of this file for
-// the deployment script DOCKER/build.sh to pick up the right label.
-const VERSION = "0.12.0-rc2"
+// the deployment script tests/build_tool.sh to pick up the right label.
+const VERSION = "0.12.0-rc3"


### PR DESCRIPTION
- correct version on develop to v0.12.0-rc3

- improve the assertion of modules (specifically consensus/tendermint) to read semantic version of dependency from vendored source code, and assert whether it is compatible with the expected version.

- also addresses deprecation item in https://github.com/eris-ltd/eris-db/issues/236