### PR TITLE
Separate integration tests from unit tests by tag, and fix remaining RPC tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,11 @@ test:
     - cd $GOPATH_REPO && go install ./cmd/eris-db
   override:
     # We only wish to test our packages not vendored ones
+    - echo "Running unit tests..."
     - cd $GOPATH_REPO && glide novendor | xargs go test -v
+    - echo "Running integration tests..."
+    - cd $GOPATH_REPO && glide novendor | xargs go test -v -tags integration
+
 
 deployment:
   master:

--- a/event/event_cache_test.go
+++ b/event/event_cache_test.go
@@ -1,6 +1,3 @@
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-
 package event
 
 import (
@@ -30,6 +27,8 @@ type mockEventData struct {
 	subId   string
 	eventId string
 }
+
+func (eventData mockEventData) AssertIsEventData() { }
 
 // A mock event
 func newMockSub(subId, eventId string, f func(txs.EventData)) mockSub {

--- a/event/events_test.go
+++ b/event/events_test.go
@@ -1,6 +1,3 @@
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-
 package event
 
 import (
@@ -9,9 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	evts "github.com/tendermint/go-events"
 	"github.com/eris-ltd/eris-db/txs"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMultiplexedEvents(t *testing.T) {

--- a/rpc/tendermint/core/websocket.go
+++ b/rpc/tendermint/core/websocket.go
@@ -67,3 +67,9 @@ func NewTendermintWebsocketServer(config *server.ServerConfig,
 		listeners: listeners,
 	}, nil
 }
+
+func (tmServer *TendermintWebsocketServer) Shutdown() {
+	for _, listener := range tmServer.listeners {
+		listener.Close()
+	}
+}

--- a/rpc/tendermint/test/client_rpc_test.go
+++ b/rpc/tendermint/test/client_rpc_test.go
@@ -18,42 +18,32 @@ func TestHTTPStatus(t *testing.T) {
 	testStatus(t, "HTTP")
 }
 
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-func testHTTPGetAccount(t *testing.T) {
+func TestHTTPGetAccount(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
 	testGetAccount(t, "HTTP")
 }
 
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-func testHTTPBroadcastTx(t *testing.T) {
+func TestHTTPBroadcastTx(t *testing.T) {
 	testBroadcastTx(t, "HTTP")
 }
 
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-func testHTTPGetStorage(t *testing.T) {
+func TestHTTPGetStorage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
 	testGetStorage(t, "HTTP")
 }
 
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-func testHTTPCallCode(t *testing.T) {
+func TestHTTPCallCode(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
 	testCallCode(t, "HTTP")
 }
 
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-func testHTTPCallContract(t *testing.T) {
+func TestHTTPCallContract(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -99,9 +89,7 @@ func TestJSONCallCode(t *testing.T) {
 	testCallCode(t, "JSONRPC")
 }
 
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-func testJSONCallContract(t *testing.T) {
+func TestJSONCallContract(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}

--- a/rpc/tendermint/test/client_rpc_test.go
+++ b/rpc/tendermint/test/client_rpc_test.go
@@ -1,3 +1,6 @@
+// +build integration
+
+// Space above here matters
 package test
 
 import (
@@ -82,9 +85,7 @@ func TestJSONBroadcastTx(t *testing.T) {
 	testBroadcastTx(t, "JSONRPC")
 }
 
-// TODO: test has been disabled and needs to be re-enabled; tracked in issue
-// https://github.com/eris-ltd/eris-db/issues/238
-func testJSONGetStorage(t *testing.T) {
+func TestJSONGetStorage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}

--- a/rpc/tendermint/test/client_ws_test.go
+++ b/rpc/tendermint/test/client_ws_test.go
@@ -218,7 +218,7 @@ func TestWSCallCall(t *testing.T) {
 	receipt = broadcastTx(t, wsTyp, tx)
 	contractAddr2 := receipt.ContractAddr
 
-	// susbscribe to the new contracts
+	// subscribe to the new contracts
 	amt = int64(10001)
 	eid := txs.EventStringAccCall(contractAddr1)
 	subId := subscribeAndGetSubscriptionId(t, wsc, eid)
@@ -244,4 +244,3 @@ func TestWSCallCall(t *testing.T) {
 func TestSubscribe(t *testing.T) {
 	testSubscribe(t)
 }
-

--- a/rpc/tendermint/test/client_ws_test.go
+++ b/rpc/tendermint/test/client_ws_test.go
@@ -1,3 +1,6 @@
+// +build integration
+
+// Space above here matters
 package test
 
 import (

--- a/rpc/tendermint/test/common.go
+++ b/rpc/tendermint/test/common.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"github.com/eris-ltd/eris-db/test/fixtures"
+	rpc_core "github.com/eris-ltd/eris-db/rpc/tendermint/core"
 	"testing"
 )
 
@@ -19,7 +20,14 @@ func TestWrapper(runner func() int) int {
 
 	// start a node
 	ready := make(chan error)
-	go newNode(ready)
+	server := make(chan *rpc_core.TendermintWebsocketServer)
+	defer func(){
+		// Shutdown -- make sure we don't hit a race on ffs.RemoveAll
+		tmServer := <-server
+		tmServer.Shutdown()
+	}()
+
+	go newNode(ready, server)
 	err = <-ready
 
 	if err != nil {

--- a/rpc/tendermint/test/common_test.go
+++ b/rpc/tendermint/test/common_test.go
@@ -1,3 +1,6 @@
+// +build integration
+
+// Space above here matters
 package test
 
 import (

--- a/rpc/tendermint/test/shared.go
+++ b/rpc/tendermint/test/shared.go
@@ -9,6 +9,7 @@ import (
 	"github.com/eris-ltd/eris-db/core"
 	core_types "github.com/eris-ltd/eris-db/core/types"
 	edbcli "github.com/eris-ltd/eris-db/rpc/tendermint/client"
+	rpc_core "github.com/eris-ltd/eris-db/rpc/tendermint/core"
 	rpc_types "github.com/eris-ltd/eris-db/rpc/tendermint/core/types"
 	"github.com/eris-ltd/eris-db/server"
 	"github.com/eris-ltd/eris-db/test/fixtures"
@@ -102,10 +103,12 @@ func makeUsers(n int) []*acm.PrivAccount {
 	return accounts
 }
 
-func newNode(ready chan error) {
+func newNode(ready chan error,
+	tmServer chan *rpc_core.TendermintWebsocketServer) {
 	// Run the 'tendermint' rpc server
-	_, err := testCore.NewGatewayTendermint(config)
+	server, err := testCore.NewGatewayTendermint(config)
 	ready <- err
+	tmServer <- server
 }
 
 func saveNewPriv() {


### PR DESCRIPTION
The approach here is to use the build tag `integration` to prevent these from running with a default invocation of `go test`. For example see: https://divan.github.io/posts/integration_testing/.

To run integration tests use:
```
go test -v -tags integration ./rpc/tendermint/test
```

~~So for the time being, these won't be run on Circle. In due course we will run them on Jenkins.~~

I have enabled the tests on circle after talking with Ben, but they are run with separately using the build tag.

I have also fixed the remaining tests that were consistently failing. I've made a couple of changes aiming to improve test stability, but we may still see some flakes, in which case I will try to fix or failing that separate persistently failing tests with further.

fixes #204.
fixes #215.
fixes #203.
fixes #202.

Also re-enabled and fixed ./event tests, so:

fixes #234.
fixes #238.