### PR TITLE
Make sure command-line arguments expanded correctly

### DIFF
--- a/bin/start_eris_db
+++ b/bin/start_eris_db
@@ -83,5 +83,5 @@ case $CMD in
 	;;
 esac
 
-echo "running eris-db serve --debug $CONFIG_OPTS $@"
-eris-db serve --debug $CONFIG_OPTS $@
+echo "running eris-db serve --debug $CONFIG_OPTS \"$@\""
+eris-db serve --debug $CONFIG_OPTS "$@"


### PR DESCRIPTION
Minor thing while I notice. In magic bash-land quoting the at-sign makes sure arguments containing spaces are properly expanding in the expansion when they are passed to the underlying command.