### PR TITLE
Might be running the integration test wrapper when we didn't intend to and multiple times

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,9 +42,9 @@ test:
   override:
     # We only wish to test our packages not vendored ones
     - echo "Running unit tests..."
-    - cd $GOPATH_REPO && glide novendor | xargs go test -v
+    - cd $GOPATH_REPO && go test -v `glide novendor`
     - echo "Running integration tests..."
-    - cd $GOPATH_REPO && glide novendor | xargs go test -v -tags integration
+    - cd $GOPATH_REPO && go test -v -tags integration `glide novendor`
 
 
 deployment:

--- a/rpc/tendermint/test/common.go
+++ b/rpc/tendermint/test/common.go
@@ -1,13 +1,18 @@
+// +build integration
+
+// Space above here matters
 package test
 
 import (
 	"github.com/eris-ltd/eris-db/test/fixtures"
 	rpc_core "github.com/eris-ltd/eris-db/rpc/tendermint/core"
 	"testing"
+	"fmt"
 )
 
-// Needs to be in a _test.go file to be picked up
+// Needs to be referenced by a *_test.go file to be picked up
 func TestWrapper(runner func() int) int {
+	fmt.Println("Running with integration TestWrapper (rpc/tendermint/test/common.go)...")
 	ffs := fixtures.NewFileFixtures("Eris-DB")
 
 	defer ffs.RemoveAll()

--- a/rpc/tendermint/test/runner/main.go
+++ b/rpc/tendermint/test/runner/main.go
@@ -1,3 +1,6 @@
+// +build integration
+
+// Space above here matters
 package main
 
 import (


### PR DESCRIPTION
This might help with the bind: port already in use issues we sometimes see in circle.