### PR TITLE
Finish testing/fixing remaining RPC methods

### DIFF
--- a/consensus/types/consensus_state.go
+++ b/consensus/types/consensus_state.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	tendermint_consensus "github.com/tendermint/tendermint/consensus"
 	tendermint_types "github.com/tendermint/tendermint/types"
 )
@@ -10,19 +12,19 @@ type ConsensusState struct {
 	Height     int                        `json:"height"`
 	Round      int                        `json:"round"`
 	Step       uint8                      `json:"step"`
-	StartTime  string                     `json:"start_time"`
-	CommitTime string                     `json:"commit_time"`
+	StartTime  time.Time                  `json:"start_time"`
+	CommitTime time.Time                  `json:"commit_time"`
 	Validators []Validator                `json:"validators"`
 	Proposal   *tendermint_types.Proposal `json:"proposal"`
 }
 
 func FromRoundState(rs *tendermint_consensus.RoundState) *ConsensusState {
 	cs := &ConsensusState{
-		CommitTime: rs.CommitTime.String(),
+		StartTime:  rs.StartTime,
+		CommitTime: rs.CommitTime,
 		Height:     rs.Height,
 		Proposal:   rs.Proposal,
 		Round:      rs.Round,
-		StartTime:  rs.StartTime.String(),
 		Step:       uint8(rs.Step),
 		Validators: FromTendermintValidators(rs.Validators.Validators),
 	}

--- a/manager/eris-mint/pipe.go
+++ b/manager/eris-mint/pipe.go
@@ -641,8 +641,17 @@ func (pipe *erisMintPipe) ListValidators() (*rpc_tm_types.ResultListValidators, 
 }
 
 func (pipe *erisMintPipe) DumpConsensusState() (*rpc_tm_types.ResultDumpConsensusState, error) {
-	return &rpc_tm_types.ResultDumpConsensusState{
+	statesMap := pipe.consensusEngine.PeerConsensusStates()
+	peerStates := make([]*rpc_tm_types.ResultPeerConsensusState, len(statesMap))
+	for key, peerState := range statesMap {
+		peerStates = append(peerStates, &rpc_tm_types.ResultPeerConsensusState{
+			PeerKey:            key,
+			PeerConsensusState: peerState,
+		})
+	}
+	dump := rpc_tm_types.ResultDumpConsensusState{
 		ConsensusState:      pipe.consensusEngine.ConsensusState(),
-		PeerConsensusStates: pipe.consensusEngine.PeerConsensusStates(),
-	}, nil
+		PeerConsensusStates: peerStates,
+	}
+	return &dump, nil
 }

--- a/rpc/tendermint/client/client.go
+++ b/rpc/tendermint/client/client.go
@@ -126,12 +126,37 @@ func BlockchainInfo(client rpcclient.Client, minHeight,
 	return res.(*rpc_types.ResultBlockchainInfo), err
 }
 
+func GetBlock(client rpcclient.Client, height int) (*rpc_types.ResultGetBlock, error) {
+	res, err := performCall(client, "get_block",
+		"height", height)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*rpc_types.ResultGetBlock), err
+}
+
 func ListUnconfirmedTxs(client rpcclient.Client) (*rpc_types.ResultListUnconfirmedTxs, error) {
 	res, err := performCall(client, "list_unconfirmed_txs")
 	if err != nil {
 		return nil, err
 	}
 	return res.(*rpc_types.ResultListUnconfirmedTxs), err
+}
+
+func ListValidators(client rpcclient.Client) (*rpc_types.ResultListValidators, error) {
+	res, err := performCall(client, "list_validators")
+	if err != nil {
+		return nil, err
+	}
+	return res.(*rpc_types.ResultListValidators), err
+}
+
+func DumpConsensusState(client rpcclient.Client) (*rpc_types.ResultDumpConsensusState, error) {
+	res, err := performCall(client, "dump_consensus_state")
+	if err != nil {
+		return nil, err
+	}
+	return res.(*rpc_types.ResultDumpConsensusState), err
 }
 
 func performCall(client rpcclient.Client, method string,

--- a/rpc/tendermint/core/routes.go
+++ b/rpc/tendermint/core/routes.go
@@ -40,8 +40,8 @@ func (tmRoutes *TendermintRoutes) GetRoutes() map[string]*rpc.RPCFunc {
 		"broadcast_tx":            rpc.NewRPCFunc(tmRoutes.BroadcastTxResult, "tx"),
 		"blockchain":              rpc.NewRPCFunc(tmRoutes.BlockchainInfo, "minHeight,maxHeight"),
 		"get_block":               rpc.NewRPCFunc(tmRoutes.GetBlock, "height"),
-		"list_validators":         rpc.NewRPCFunc(tmRoutes.ListValidators, ""),
 		"list_unconfirmed_txs":    rpc.NewRPCFunc(tmRoutes.ListUnconfirmedTxs, ""),
+		"list_validators":         rpc.NewRPCFunc(tmRoutes.ListValidators, ""),
 		"dump_consensus_state":    rpc.NewRPCFunc(tmRoutes.DumpConsensusState, ""),
 		"unsafe/gen_priv_account": rpc.NewRPCFunc(tmRoutes.GenPrivAccountResult, ""),
 		"unsafe/sign_tx":          rpc.NewRPCFunc(tmRoutes.SignTxResult, "tx,privAccounts"),
@@ -237,10 +237,6 @@ func (tmRoutes *TendermintRoutes) ListValidators() (ctypes.ErisDBResult, error) 
 	}
 }
 func (tmRoutes *TendermintRoutes) DumpConsensusState() (ctypes.ErisDBResult, error) {
-	r, err := tmRoutes.tendermintPipe.DumpConsensusState()
-	if err != nil {
-		return nil, err
-	} else {
-		return r, nil
-	}
+	return tmRoutes.tendermintPipe.DumpConsensusState()
 }
+

--- a/rpc/tendermint/core/types/responses.go
+++ b/rpc/tendermint/core/types/responses.go
@@ -1,4 +1,4 @@
-package core_types
+package types
 
 import (
 	acm "github.com/eris-ltd/eris-db/account"
@@ -83,7 +83,12 @@ type ResultListValidators struct {
 
 type ResultDumpConsensusState struct {
 	ConsensusState      *consensus_types.ConsensusState `json:"consensus_state"`
-	PeerConsensusStates map[string]string              `json:"peer_consensus_states"`
+	PeerConsensusStates []*ResultPeerConsensusState      `json:"peer_consensus_states"`
+}
+
+type ResultPeerConsensusState struct {
+	PeerKey            string `json:"peer_key"`
+	PeerConsensusState string `json:"peer_consensus_state"`
 }
 
 type ResultListNames struct {
@@ -152,6 +157,7 @@ const (
 	ResultTypeEvent              = byte(0x13) // so websockets can respond to rpc functions
 	ResultTypeSubscribe          = byte(0x14)
 	ResultTypeUnsubscribe        = byte(0x15)
+	ResultTypePeerConsensusState = byte(0x16)
 )
 
 type ErisDBResult interface {
@@ -170,6 +176,7 @@ func ConcreteTypes() []wire.ConcreteType {
 		{&ResultNetInfo{}, ResultTypeNetInfo},
 		{&ResultListValidators{}, ResultTypeListValidators},
 		{&ResultDumpConsensusState{}, ResultTypeDumpConsensusState},
+		{&ResultDumpConsensusState{}, ResultTypePeerConsensusState},
 		{&ResultListNames{}, ResultTypeListNames},
 		{&ResultGenPrivAccount{}, ResultTypeGenPrivAccount},
 		{&ResultGetAccount{}, ResultTypeGetAccount},

--- a/rpc/tendermint/core/types/responses_test.go
+++ b/rpc/tendermint/core/types/responses_test.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"testing"
+
+	"time"
+
+	consensus_types "github.com/eris-ltd/eris-db/consensus/types"
+	"github.com/tendermint/go-wire"
+	tendermint_types "github.com/tendermint/tendermint/types"
+)
+
+func TestResultDumpConsensusState(t *testing.T) {
+	result := ResultDumpConsensusState{
+		ConsensusState: &consensus_types.ConsensusState{
+			Height:     3,
+			Round:      1,
+			Step:       uint8(1),
+			StartTime:  time.Now().Add(-time.Second * 100),
+			CommitTime: time.Now().Add(-time.Second * 10),
+			Validators: []consensus_types.Validator{
+				&consensus_types.TendermintValidator{},
+			},
+			Proposal: &tendermint_types.Proposal{},
+		},
+		PeerConsensusStates: []*ResultPeerConsensusState{
+			{
+				PeerKey:            "Foo",
+				PeerConsensusState: "Bar",
+			},
+		},
+	}
+	wire.JSONBytes(result)
+}

--- a/rpc/tendermint/test/shared.go
+++ b/rpc/tendermint/test/shared.go
@@ -21,6 +21,7 @@ import (
 
 	"path"
 
+	state_types "github.com/eris-ltd/eris-db/manager/eris-mint/state/types"
 	"github.com/spf13/viper"
 	tm_common "github.com/tendermint/go-common"
 	"github.com/tendermint/tendermint/types"
@@ -33,14 +34,13 @@ var (
 	mempoolCount      = 0
 	chainID           string
 	websocketAddr     string
+	genesisDoc        *state_types.GenesisDoc
 	websocketEndpoint string
-
-	user          = makeUsers(5) // make keys
-	jsonRpcClient rpcclient.Client
-	httpClient    rpcclient.Client
-	clients       map[string]rpcclient.Client
-
-	testCore *core.Core
+	user              = makeUsers(5) // make keys
+	jsonRpcClient     rpcclient.Client
+	httpClient        rpcclient.Client
+	clients           map[string]rpcclient.Client
+	testCore          *core.Core
 )
 
 // initialize config and create new node
@@ -49,6 +49,7 @@ func initGlobalVariables(ffs *fixtures.FileFixtures) error {
 	rootWorkDir = ffs.AddDir("rootWorkDir")
 	rootDataDir := ffs.AddDir("rootDataDir")
 	genesisFile := ffs.AddFile("rootWorkDir/genesis.json", defaultGenesis)
+	genesisDoc = state_types.GenesisDocFromJSON([]byte(defaultGenesis))
 
 	if ffs.Error != nil {
 		return ffs.Error

--- a/rpc/tendermint/test/websocket_client_test.go
+++ b/rpc/tendermint/test/websocket_client_test.go
@@ -20,13 +20,13 @@ import (
 
 // make a simple connection to the server
 func TestWSConnect(t *testing.T) {
-	wsc := newWSClient(t)
+	wsc := newWSClient()
 	wsc.Stop()
 }
 
 // receive a new block message
 func TestWSNewBlock(t *testing.T) {
-	wsc := newWSClient(t)
+	wsc := newWSClient()
 	eid := txs.EventStringNewBlock()
 	subId := subscribeAndGetSubscriptionId(t, wsc, eid)
 	defer func() {
@@ -45,7 +45,7 @@ func TestWSBlockchainGrowth(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	wsc := newWSClient(t)
+	wsc := newWSClient()
 	eid := txs.EventStringNewBlock()
 	subId := subscribeAndGetSubscriptionId(t, wsc, eid)
 	defer func() {
@@ -78,10 +78,9 @@ func TestWSBlockchainGrowth(t *testing.T) {
 
 // send a transaction and validate the events from listening for both sender and receiver
 func TestWSSend(t *testing.T) {
+	wsc := newWSClient()
 	toAddr := user[1].Address
 	amt := int64(100)
-
-	wsc := newWSClient(t)
 	eidInput := txs.EventStringAccInput(user[0].Address)
 	eidOutput := txs.EventStringAccOutput(toAddr)
 	subIdInput := subscribeAndGetSubscriptionId(t, wsc, eidInput)
@@ -105,7 +104,7 @@ func TestWSDoubleFire(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	wsc := newWSClient(t)
+	wsc := newWSClient()
 	eid := txs.EventStringAccInput(user[0].Address)
 	subId := subscribeAndGetSubscriptionId(t, wsc, eid)
 	defer func() {
@@ -136,7 +135,7 @@ func TestWSCallWait(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	wsc := newWSClient(t)
+	wsc := newWSClient()
 	eid1 := txs.EventStringAccInput(user[0].Address)
 	subId1 := subscribeAndGetSubscriptionId(t, wsc, eid1)
 	defer func() {
@@ -175,7 +174,7 @@ func TestWSCallNoWait(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	wsc := newWSClient(t)
+	wsc := newWSClient()
 	amt, gasLim, fee := int64(10000), int64(1000), int64(1000)
 	code, _, returnVal := simpleContract()
 
@@ -204,7 +203,7 @@ func TestWSCallCall(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	wsc := newWSClient(t)
+	wsc := newWSClient()
 	amt, gasLim, fee := int64(10000), int64(1000), int64(1000)
 	code, _, returnVal := simpleContract()
 	txid := new([]byte)
@@ -243,8 +242,8 @@ func TestWSCallCall(t *testing.T) {
 }
 
 func TestSubscribe(t *testing.T) {
+	wsc := newWSClient()
 	var subId string
-	wsc := newWSClient(t)
 	subscribe(t, wsc, txs.EventStringNewBlock())
 
 	timeout := time.NewTimer(timeoutSeconds * time.Second)

--- a/rpc/tendermint/test/websocket_helpers.go
+++ b/rpc/tendermint/test/websocket_helpers.go
@@ -24,10 +24,10 @@ const (
 type blockPredicate func(block *tm_types.Block) bool
 
 // create a new connection
-func newWSClient(t *testing.T) *rpcclient.WSClient {
+func newWSClient() *rpcclient.WSClient {
 	wsc := rpcclient.NewWSClient(websocketAddr, websocketEndpoint)
 	if _, err := wsc.Start(); err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 	return wsc
 }

--- a/test/testdata/testdata/testdata.go
+++ b/test/testdata/testdata/testdata.go
@@ -272,8 +272,8 @@ var testDataJson = `
       "height": 1,
       "round": 0,
       "step": 1,
-      "start_time": "",
-      "commit_time": "0001-01-01 00:00:00 +0000 UTC",
+      "start_time": "2016-09-18T10:03:55.100Z",
+      "commit_time": "2016-09-18T10:04:00.100Z",
       "validators": [
         [
           1,


### PR DESCRIPTION
This adds tests and fixes some issues with the previously unimplemented RPC methods:

- `GetBlock`
- `ListValidators`
- `DumpConsensusState`

fixes #216 
fixes #221 
fixes #217 
fixes #220 
fixes #219 
fixes #275 
