### PR TITLE
DO NOT MERGE: Move tendermint validator to consensus tendermint

### DIFF
--- a/client/mock/client_mock.go
+++ b/client/mock/client_mock.go
@@ -19,6 +19,8 @@ package mock
 import (
 	"github.com/tendermint/go-crypto"
 
+	consensus_types "github.com/eris-ltd/eris-db/consensus/types"
+	core_types "github.com/eris-ltd/eris-db/core/types"
 	acc "github.com/eris-ltd/eris-db/account"
 	. "github.com/eris-ltd/eris-db/client"
 	"github.com/eris-ltd/eris-db/txs"
@@ -99,4 +101,17 @@ func (mock *MockNodeClient) QueryContractCode(address, code, data []byte) (ret [
 	// return zero
 	ret = make([]byte, 0)
 	return ret, 0, nil
+}
+
+
+func (mock *MockNodeClient) DumpStorage(address []byte) (storage *core_types.Storage, err error) {
+	return nil, nil
+}
+
+func (mock *MockNodeClient) GetName(name string) (owner []byte, data string, expirationBlock int, err error) {
+	return nil, "", 0, nil
+}
+
+func (mock *MockNodeClient) ListValidators() (blockHeight int, bondedValidators, unbondingValidators []consensus_types.Validator, err error){
+	return 0, nil, nil, nil
 }

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -240,7 +240,7 @@ func (tendermint *Tendermint) ListUnconfirmedTxs(
 }
 
 func (tendermint *Tendermint) ListValidators() []consensus_types.Validator {
-	return consensus_types.FromTendermintValidators(tendermint.tmintNode.
+	return FromTendermintValidators(tendermint.tmintNode.
 		ConsensusState().Validators.Validators)
 }
 

--- a/consensus/tendermint/types.go
+++ b/consensus/tendermint/types.go
@@ -1,0 +1,52 @@
+// Copyright 2015, 2016 Eris Industries (UK) Ltd.
+// This file is part of Eris-RT
+
+// Eris-RT is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Eris-RT is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Eris-RT.  If not, see <http://www.gnu.org/licenses/>.
+
+package tendermint
+
+import (
+	tendermint_types "github.com/tendermint/tendermint/types"
+
+	consensus_types "github.com/eris-ltd/eris-db/consensus/types"
+)
+
+// Anticipating moving to our own definition of Validator, or at least
+// augmenting Tendermint's.
+type TendermintValidator struct {
+	tmintValidator *tendermint_types.Validator `json:"validator"`
+}
+
+var _ consensus_types.Validator = (*TendermintValidator)(nil)
+
+func (tendermintValidator *TendermintValidator) AssertIsValidator() {
+
+}
+
+func (tendermintValidator *TendermintValidator) Address() []byte {
+	return tendermintValidator.tmintValidator.Address
+}
+
+//-------------------------------------------------------------------------------------
+// Helper function for TendermintValidator
+
+func FromTendermintValidators(tmValidators []*tendermint_types.Validator) []Validator {
+	validators := make([]Validator, len(tmValidators))
+	for i, tmValidator := range tmValidators {
+		// This embedding could be replaced by a mapping once if we want to describe
+		// a more general notion of validator
+		validators[i] = &TendermintValidator{tmintValidator: tmValidator}
+	}
+	return validators
+}

--- a/consensus/types/validator.go
+++ b/consensus/types/validator.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"github.com/tendermint/go-wire"
-	tendermint_types "github.com/tendermint/tendermint/types"
 )
 
 var _ = wire.RegisterInterface(
@@ -13,33 +12,4 @@ var _ = wire.RegisterInterface(
 type Validator interface {
 	AssertIsValidator()
 	Address() []byte
-}
-
-// Anticipating moving to our own definition of Validator, or at least
-// augmenting Tendermint's.
-type TendermintValidator struct {
-	tmintValidator *tendermint_types.Validator `json:"validator"`
-}
-
-var _ Validator = (*TendermintValidator)(nil)
-
-func (tendermintValidator *TendermintValidator) AssertIsValidator() {
-
-}
-
-func (tendermintValidator *TendermintValidator) Address() []byte {
-	return tendermintValidator.tmintValidator.Address
-}
-
-//-------------------------------------------------------------------------------------
-// Helper function for TendermintValidator
-
-func FromTendermintValidators(tmValidators []*tendermint_types.Validator) []Validator {
-	validators := make([]Validator, len(tmValidators))
-	for i, tmValidator := range tmValidators {
-		// This embedding could be replaced by a mapping once if we want to describe
-		// a more general notion of validator
-		validators[i] = &TendermintValidator{tmintValidator: tmValidator}
-	}
-	return validators
 }

--- a/consensus/types/validator.go
+++ b/consensus/types/validator.go
@@ -12,26 +12,34 @@ var _ = wire.RegisterInterface(
 
 type Validator interface {
 	AssertIsValidator()
+	Address() []byte
 }
 
 // Anticipating moving to our own definition of Validator, or at least
 // augmenting Tendermint's.
 type TendermintValidator struct {
-	*tendermint_types.Validator `json:"validator"`
-}
-
-func (validator *TendermintValidator) AssertIsValidator() {
-
+	tmintValidator *tendermint_types.Validator `json:"validator"`
 }
 
 var _ Validator = (*TendermintValidator)(nil)
+
+func (tendermintValidator *TendermintValidator) AssertIsValidator() {
+
+}
+
+func (tendermintValidator *TendermintValidator) Address() []byte {
+	return tendermintValidator.tmintValidator.Address
+}
+
+//-------------------------------------------------------------------------------------
+// Helper function for TendermintValidator
 
 func FromTendermintValidators(tmValidators []*tendermint_types.Validator) []Validator {
 	validators := make([]Validator, len(tmValidators))
 	for i, tmValidator := range tmValidators {
 		// This embedding could be replaced by a mapping once if we want to describe
 		// a more general notion of validator
-		validators[i] = &TendermintValidator{tmValidator}
+		validators[i] = &TendermintValidator{tmintValidator: tmValidator}
 	}
 	return validators
 }


### PR DESCRIPTION
POST rc3

consideration of avoiding exposure for tendermint types; but if we do it with an interface for tendermints validator; then logically you'd do it for all types defined by tendermint; which leaves no generalisation.

This seems to be a bad direction, rather I'd keep interfaces behaviorally, recasting the type into e-dnb types at a single interface; in this case consensusEngine
