### PR TITLE
We were (probably) inadvertently depending on Tendermint's native RPC

### DIFF
--- a/consensus/tendermint/config.go
+++ b/consensus/tendermint/config.go
@@ -73,7 +73,7 @@ func (tmintConfig *TendermintConfig) AssertTendermintDefaults(chainId, workDir,
 	tmintConfig.SetDefault("db_backend", "leveldb")
 	tmintConfig.SetDefault("db_dir", dataDir)
 	tmintConfig.SetDefault("log_level", "info")
-	tmintConfig.SetDefault("rpc_laddr", "0.0.0.0:46657")
+	tmintConfig.SetDefault("rpc_laddr", "")
 	tmintConfig.SetDefault("prof_laddr", "")
 	tmintConfig.SetDefault("revision_file", path.Join(workDir, "revision"))
 	tmintConfig.SetDefault("cswal", path.Join(dataDir, "cswal"))
@@ -103,6 +103,7 @@ func (tmintConfig *TendermintConfig) AssertTendermintConsistency(
 	tmintConfig.Set("genesis_file", consensusConfig.GenesisFile)
 	// private validator file
 	tmintConfig.Set("priv_validator_file", privateValidatorFilePath)
+
 }
 
 // implement interface github.com/tendermint/go-config/config.Config

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -111,6 +111,16 @@ func NewTendermint(moduleConfig *config.ModuleConfig,
 		path.Join(moduleConfig.RootDir,
 			moduleConfig.Config.GetString("private_validator_file")))
 
+	// TODO: [Silas] we want to something better than this like not not have it in
+	// the config at all, but for now I think it's much safer to make sure we are
+	// not running the tendermint RPC as it could lead to unexpected behaviour,
+	// not least if we accidentally try to run it on the same address as our own
+	if tmintConfig.GetString("rpc_laddr") != "" {
+		log.Warnf("Force disabling Tendermint's native RPC, which had been set to " +
+				"run on '%s' in the Tendermint config.", tmintConfig.GetString("rpc_laddr"))
+		tmintConfig.Set("rpc_laddr", "")
+	}
+	
 	newNode := node.NewNode(tmintConfig, privateValidator, func(_, _ string,
 		hash []byte) proxy.AppConn {
 		return NewLocalClient(new(sync.Mutex), application)

--- a/rpc/tendermint/test/config.go
+++ b/rpc/tendermint/test/config.go
@@ -173,7 +173,7 @@ private_validator_file = "priv_validator.json"
   # rpc local address
 	# NOTE: value is ignored when run in-process as RPC is
 	# handled by [servers.tendermint]
-  rpc_laddr = "0.0.0.0:36657"
+  rpc_laddr = ""
   # proxy application address - used for tmsp connections,
   # and this port should not be exposed for in-process Tendermint
   proxy_app = "tcp://127.0.0.1:46658"
@@ -217,6 +217,4 @@ private_validator_file = "priv_validator.json"
 [erismint]
 # Database backend to use for ErisMint state database.
 db_backend = "leveldb"
-# tendermint host address needs to correspond to tendermints configuration
-# of the rpc local address
-tendermint_host = "0.0.0.0:36657"`
+`

--- a/rpc/tendermint/test/shared.go
+++ b/rpc/tendermint/test/shared.go
@@ -64,9 +64,8 @@ func initGlobalVariables(ffs *fixtures.FileFixtures) error {
 	}
 
 	chainID = testConfig.GetString("chain.assert_chain_id")
-	rpcAddr := testConfig.GetString("erismint.tendermint_host")
+	rpcAddr := config.Tendermint.RpcLocalAddress
 	websocketAddr = rpcAddr
-	config.Tendermint.RpcLocalAddress = rpcAddr
 	websocketEndpoint = "/websocket"
 
 	consensusConfig, err := core.LoadModuleConfig(testConfig, rootWorkDir,

--- a/server_config.toml
+++ b/server_config.toml
@@ -101,10 +101,10 @@ genesis_file = "genesis.json"
   read_buffer_size = 4096
   write_buffer_size = 4096
 
-	[servers.tendermint]
-	# Multiple listeners can be separated with a comma
-	rpc_local_address = "0.0.0.0:46657"
-	endpoint = "/websocket"
+  [servers.tendermint]
+  # Multiple listeners can be separated with a comma
+  rpc_local_address = "0.0.0.0:46657"
+  endpoint = "/websocket"
 
   [servers.logging]
   console_log_level = "info"
@@ -172,9 +172,9 @@ private_validator_file = "priv_validator.json"
   # node local address
   node_laddr = "0.0.0.0:46656"
   # rpc local address
-	# NOTE: value is ignored when run in-process as RPC is
-	# handled by [servers.tendermint]
-  rpc_laddr = "0.0.0.0:46657"
+  # NOTE: value is ignored when run in-process as RPC is
+  # handled by [servers.tendermint]
+  rpc_laddr = ""
   # proxy application address - used for tmsp connections,
   # and this port should not be exposed for in-process Tendermint
   proxy_app = "tcp://127.0.0.1:46658"
@@ -239,6 +239,3 @@ private_validator_file = "priv_validator.json"
 # Database backend to use for ErisMint state database.
 # Supported `leveldb` and `memdb`.
 db_backend = "leveldb"
-# tendermint host address needs to correspond to tendermints configuration
-# of the rpc local address
-tendermint_host = "0.0.0.0:46657"


### PR DESCRIPTION
I noticed that transactor was relying on a Tendermint native RPC call `broadcast_tx_sync`:

```
_, err = app.client.Call("broadcast_tx_sync", params, &result)
```

One that we no longer support. We could implement it, or we could port it to call our RPC, but then this would still be one RPC making another HTTP request to talk to another RPC in the same process, which makes little sense. It ended up this way as we adopted a cautious approach in the refactor.

I have elected to instead delegate to our existing tested BroadcastTx implementation.

...

This also lead me to look at the history of the 'tendermint' endpoint (running on 46657 by default). This RPC was split into our 'rpc/tendermint' and Tendermint's own native RPC. Since we are running in-process we have no real need to run Tendermint's RPC (and it seems to me less can go wrong if we don't), but transactor was still expecting a Tendermint endpoint (though it looked similar to ours).

I then noticed that we are actually trying to run both our rpc/tendermint and Tendermint's native RPC on the same address and port (46657 by default). This obviously will not work. I think the best thing is to not run the Tendermint native one at all for now.

I have tried to take an approach that either simplifies or leaves things alone. I was tempted to rename/rearrange some config, but the fix works without that so I have avoided it.