### PR TITLE
Reintroduce Send and SendAndHold

### DIFF
--- a/definitions/pipe.go
+++ b/definitions/pipe.go
@@ -77,6 +77,8 @@ type Transactor interface {
 		fee int64) (*txs.Receipt, error)
 	TransactAndHold(privKey, address, data []byte, gasLimit,
 		fee int64) (*txs.EventDataCall, error)
+  Send(privKey, toAddress []byte, amount int64) (*txs.Receipt, error)
+	SendAndHold(privKey, toAddress []byte, amount int64) (*txs.Receipt, error)
 	TransactNameReg(privKey []byte, name, data string, amount,
 		fee int64) (*txs.Receipt, error)
 	SignTx(tx txs.Tx, privAccounts []*account.PrivAccount) (txs.Tx, error)

--- a/manager/eris-mint/transactor.go
+++ b/manager/eris-mint/transactor.go
@@ -252,6 +252,97 @@ func (this *transactor) TransactAndHold(privKey, address, data []byte, gasLimit,
 	return ret, rErr
 }
 
+func (this *transactor) Send(privKey, toAddress []byte,
+	amount int64) (*txs.Receipt, error) {
+	var toAddr []byte
+	if len(toAddress) == 0 {
+		toAddr = nil
+	} else if len(toAddress) != 20 {
+		return nil, fmt.Errorf("To-address is not of the right length: %d\n",
+			len(toAddress))
+	} else {
+		toAddr = toAddress
+	}
+
+	if len(privKey) != 64 {
+		return nil, fmt.Errorf("Private key is not of the right length: %d\n",
+			len(privKey))
+	}
+
+	pk := &[64]byte{}
+	copy(pk[:], privKey)
+	this.txMtx.Lock()
+	defer this.txMtx.Unlock()
+	pa := account.GenPrivAccountFromPrivKeyBytes(privKey)
+	cache := this.erisMint.GetState()
+	acc := cache.GetAccount(pa.Address)
+	var sequence int
+	if acc == nil {
+		sequence = 1
+	} else {
+		sequence = acc.Sequence + 1
+	}
+
+	tx := txs.NewSendTx()
+
+	txInput := &txs.TxInput{
+		Address:  pa.Address,
+		Amount:   amount,
+		Sequence: sequence,
+		PubKey:   pa.PubKey,
+	}
+
+	tx.Inputs = append(tx.Inputs, txInput)
+
+	txOutput := &txs.TxOutput{toAddr, amount}
+
+	tx.Outputs = append(tx.Outputs, txOutput)
+
+	// Got ourselves a tx.
+	txS, errS := this.SignTx(tx, []*account.PrivAccount{pa})
+	if errS != nil {
+		return nil, errS
+	}
+	return this.BroadcastTx(txS)
+}
+
+func (this *transactor) SendAndHold(privKey, toAddress []byte,
+	amount int64) (*txs.Receipt, error) {
+	rec, tErr := this.Send(privKey, toAddress, amount)
+	if tErr != nil {
+		return nil, tErr
+	}
+
+	wc := make(chan *txs.SendTx)
+	subId := fmt.Sprintf("%X", rec.TxHash)
+
+	this.eventEmitter.Subscribe(subId, txs.EventStringAccOutput(toAddress),
+		func(evt txs.EventData) {
+			event := evt.(txs.EventDataTx)
+			tx := event.Tx.(*txs.SendTx)
+			wc <- tx
+		})
+
+	timer := time.NewTimer(300 * time.Second)
+	toChan := timer.C
+
+	var rErr error
+
+	pa := account.GenPrivAccountFromPrivKeyBytes(privKey)
+
+	select {
+	case <-toChan:
+		rErr = fmt.Errorf("Transaction timed out. Hash: " + subId)
+	case e := <-wc:
+		if bytes.Equal(e.Inputs[0].Address, pa.Address) && e.Inputs[0].Amount == amount {
+			timer.Stop()
+			this.eventEmitter.Unsubscribe(subId)
+			return rec, rErr
+		}
+	}
+	return nil, rErr
+}
+
 func (this *transactor) TransactNameReg(privKey []byte, name, data string,
 	amount, fee int64) (*txs.Receipt, error) {
 

--- a/rpc/v0/methods.go
+++ b/rpc/v0/methods.go
@@ -43,6 +43,8 @@ const (
 	SIGN_TX                   = SERVICE_NAME + ".signTx"
 	TRANSACT                  = SERVICE_NAME + ".transact"
 	TRANSACT_AND_HOLD         = SERVICE_NAME + ".transactAndHold"
+	SEND                      = SERVICE_NAME + ".send"
+	SEND_AND_HOLD             = SERVICE_NAME + ".sendAndHold"
 	TRANSACT_NAMEREG          = SERVICE_NAME + ".transactNameReg"
 	EVENT_SUBSCRIBE           = SERVICE_NAME + ".eventSubscribe" // Events
 	EVENT_UNSUBSCRIBE         = SERVICE_NAME + ".eventUnsubscribe"
@@ -108,6 +110,8 @@ func (erisDbMethods *ErisDbMethods) getMethods() map[string]RequestHandlerFunc {
 	dhMap[SIGN_TX] = erisDbMethods.SignTx
 	dhMap[TRANSACT] = erisDbMethods.Transact
 	dhMap[TRANSACT_AND_HOLD] = erisDbMethods.TransactAndHold
+	dhMap[SEND] = erisDbMethods.Send
+	dhMap[SEND_AND_HOLD] = erisDbMethods.SendAndHold
 	dhMap[TRANSACT_NAMEREG] = erisDbMethods.TransactNameReg
 	// Namereg
 	dhMap[GET_NAMEREG_ENTRY] = erisDbMethods.NameRegEntry
@@ -377,6 +381,32 @@ func (erisDbMethods *ErisDbMethods) TransactAndHold(request *rpc.RPCRequest, req
 		return nil, rpc.INTERNAL_ERROR, errC
 	}
 	return ce, 0, nil
+}
+
+func (this *ErisDbMethods) Send(request *rpc.RPCRequest, requester interface{}) (interface{}, int, error) {
+	param := &SendParam{}
+	err := this.codec.DecodeBytes(param, request.Params)
+	if err != nil {
+		return nil, rpc.INVALID_PARAMS, err
+	}
+	receipt, errC := this.pipe.Transactor().Send(param.PrivKey, param.ToAddress, param.Amount)
+	if errC != nil {
+		return nil, rpc.INTERNAL_ERROR, errC
+	}
+	return receipt, 0, nil
+}
+
+func (this *ErisDbMethods) SendAndHold(request *rpc.RPCRequest, requester interface{}) (interface{}, int, error) {
+	param := &SendParam{}
+	err := this.codec.DecodeBytes(param, request.Params)
+	if err != nil {
+		return nil, rpc.INVALID_PARAMS, err
+	}
+	rec, errC := this.pipe.Transactor().SendAndHold(param.PrivKey, param.ToAddress, param.Amount)
+	if errC != nil {
+		return nil, rpc.INTERNAL_ERROR, errC
+	}
+	return rec, 0, nil
 }
 
 func (erisDbMethods *ErisDbMethods) TransactNameReg(request *rpc.RPCRequest, requester interface{}) (interface{}, int, error) {

--- a/rpc/v0/params.go
+++ b/rpc/v0/params.go
@@ -90,6 +90,13 @@ type (
 		GasLimit int64  `json:"gas_limit"`
 	}
 
+	// Used when sending a 'Send' transaction.
+	SendParam struct {
+		PrivKey   []byte `json:"priv_key"`
+		ToAddress []byte `json:"to_address"`
+		Amount    int64  `json:"amount"`
+	}
+
 	NameRegEntryParam struct {
 		Name string `json:"name"`
 	}


### PR DESCRIPTION
Probably shouldn't have been removed.

fixes #298 
fixes #155

Note that the old implementation: https://github.com/eris-ltd/eris-db/pull/114/commits/b2d0b4d402319dbfef914354750bb69dae728025

used:
```
cache := this.mempoolReactor.Mempool.GetCache()
￼acc := cache.GetAccount(pa.Address)
```

whereas we use:

```
cache := this.erisMint.GetState()
￼acc := cache.GetAccount(pa.Address)
```

This follows Call