### PR TITLE
Bump version, but label as development version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -129,4 +129,4 @@ func (version *VersionIdentifier) MatchesMinorVersion(
 
 // IMPORTANT: Eris-DB version must be on the last line of this file for
 // the deployment script tests/build_tool.sh to pick up the right label.
-const VERSION = "0.12.0-rc3"
+const VERSION = "0.12.0-develop"


### PR DESCRIPTION
Suggest that we merge this before the 0.12.0-RC3 PR to avoid accidentally releasing over the top of the quay image in future. Also suggest that we adopt the convention of sufficing our version on the develop branch with `-develop` so that we never push to a quay tag that ought to be reserved for a real non-development version.