### PR TITLE
glide: update eris/common hash

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -23,8 +23,11 @@ imports:
   version: f0aeabca5a127c4078abb8c8d64298b147264b55
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+- name: github.com/eris-ltd/common
+  version: 8ca15f5455104403db4202c995e2f6e161654c02
   subpackages:
-  - spew
+  - go/docs
+  - go/common
 - name: github.com/eris-ltd/eris-keys
   version: 114ebc77443db9a153692233294e48bc7e184215
 - name: github.com/eris-ltd/eris-logger
@@ -212,6 +215,4 @@ imports:
   version: ecde8c8f16df93a994dda8936c8f60f0c26c28ab
 - name: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
-- name: github.com/eris-ltd/common
-  version: 8d928eec1d46942444f81eaa33c06da1c6e48ed9
 devImports: []


### PR DESCRIPTION
develop was broken on changes to git history of common