### PR TITLE
issue371: hotfix 0.12.1

### DIFF
--- a/manager/eris-mint/evm/vm.go
+++ b/manager/eris-mint/evm/vm.go
@@ -156,7 +156,9 @@ func (vm *VM) DelegateCall(caller, callee *Account, code, input []byte, value in
 
 	exception := new(string)
 	// fire the post call event (including exception if applicable)
-	defer vm.fireCallEvent(exception, &output, caller, callee, input, value, gas)
+	// NOTE: [ben] hotfix for issue 371;
+	// introduce event EventStringAccDelegateCall Acc/%X/DelegateCall
+	// defer vm.fireCallEvent(exception, &output, caller, callee, input, value, gas)
 
 	// DelegateCall does not transfer the value to the callee.
 

--- a/version/version.go
+++ b/version/version.go
@@ -34,7 +34,7 @@ const (
 	// Minor version component of the current release
 	erisVersionMinor = 12
 	// Patch version component of the current release
-	erisVersionPatch = 0
+	erisVersionPatch = 1
 )
 
 var erisVersion *VersionIdentifier
@@ -129,4 +129,4 @@ func (version *VersionIdentifier) MatchesMinorVersion(
 
 // IMPORTANT: Eris-DB version must be on the last line of this file for
 // the deployment script tests/build_tool.sh to pick up the right label.
-const VERSION = "0.12.0"
+const VERSION = "0.12.1"


### PR DESCRIPTION
eris-mint/vm: issue371, hotfix silence event call for delegate call as no transaction can commence with delegatecall

is a hotfix for #371; but needs a more elegant solution:
```introduce event EventStringAccDelegateCall Acc/%X/DelegateCall```