### PR TITLE
Issue 411 structure build and test pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # do not vendor in dependencies
 vendor
+
+# build target
+target
+
 # Temporary / cached
 *.swp
 debug

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -3,13 +3,8 @@ MAINTAINER Monax <support@monax.io>
 
 ENV TARGET eris-db
 
-# runtime customization start here
-COPY ./eris-client $INSTALL_BASE/eris-client
-COPY ./bin/start_eris_db $INSTALL_BASE/erisdb-wrapper
-# runtime customization end here
-
-# Get the binary from the artifact in pwd
-COPY ./"$TARGET"_build_artifact $INSTALL_BASE/$TARGET
+# Get the binary from the artefact in pwd/target/docker
+COPY ./target/docker/"$TARGET".dockerartefact $INSTALL_BASE/$TARGET
 RUN chmod +x --recursive $INSTALL_BASE
 
 # Finalize

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# TARGET = eris-db
+# IMAGE = quay.io/eris/db
+
+SHELL := /bin/bash
+GOFILES_NOVENDOR := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+PACKAGES_NOVENDOR := $(shell go list github.com/eris-ltd/eris-db/... | grep -v /vendor/)
+VERSION_MIN := $(shell cat ./version/version.go | tail -n 1 | cut -d \  -f 4 | tr -d '"')
+VERSION_MAJ := $(shell echo ${VERSION_MIN} | cut -d . -f 1-2)
+
+.PHONY: greet
+greet:
+	@echo "Hi! I'm the marmot that will help you with eris-db v${VERSION_MIN}"
+
+### Formatting, linting and vetting
+
+# check the code for style standards; currently enforces go formatting.
+# display output first, then check for success	
+.PHONY: check
+check:
+	@echo "Checking code for formatting style compliance."
+	@gofmt -l -d ${GOFILES_NOVENDOR}
+	@gofmt -l ${GOFILES_NOVENDOR} | read && echo && echo "Your marmot has found a problem with the formatting style of the code." 1>&2 && exit 1 || true
+
+# fmt runs gofmt -w on the code, modifying any files that do not match
+# the style guide.
+.PHONY: fmt
+fmt:
+	@echo "Correcting any formatting style corrections."
+	@gofmt -l -w ${GOFILES_NOVENDOR}
+
+# lint installs golint and prints recommendations for coding style.
+lint: 
+	@echo "Running lint checks."
+	go get -u github.com/golang/lint/golint
+	@for file in $(GOFILES_NOVENDOR); do \
+		echo; \
+		golint --set_exit_status $${file}; \
+	done
+
+# vet runs extended compilation checks to find recommendations for
+# suspicious code constructs.
+.PHONY: vet
+vet:
+	@echo "Running go vet."
+	@go vet ${PACKAGES_NOVENDOR}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOFILES_NOVENDOR := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 PACKAGES_NOVENDOR := $(shell go list github.com/eris-ltd/eris-db/... | grep -v /vendor/)
 VERSION_MIN := $(shell cat ./version/version.go | tail -n 1 | cut -d \  -f 4 | tr -d '"')
 VERSION_MAJ := $(shell echo ${VERSION_MIN} | cut -d . -f 1-2)
+COMMIT_SHA := $(shell echo `git rev-parse --short --verify HEAD`)
 BUILD_DIR?=target
 
 .PHONY: greet
@@ -58,12 +59,12 @@ build_race:	build_race_db build_race_client build_race_keys
 # build eris-db
 .PHONY: build_db
 build_db:
-	go build -o ${BUILD_DIR}/eris-db ./cmd/eris-db
+	go build -o ${BUILD_DIR}/eris-db-${COMMIT_SHA} ./cmd/eris-db
 
 # build eris-client
 .PHONY: build_client
 build_client:
-	go build -o ${BUILD_DIR}/eris-client ./client/cmd/eris-client
+	go build -o ${BUILD_DIR}/eris-client-${COMMIT_SHA} ./client/cmd/eris-client
 
 # build eris-keys
 .PHONY: build_keys
@@ -73,12 +74,12 @@ build_keys:
 # build eris-db with checks for race conditions
 .PHONY: build_race_db
 build_race_db:
-	go build -race -o ${BUILD_DIR}/eris-db ./cmd/eris-db
+	go build -race -o ${BUILD_DIR}/eris-db-${COMMIT_SHA} ./cmd/eris-db
 
 # build eris-client with checks for race conditions
 .PHONY: build_race_client
 build_race_client:
-	go build -race -o ${BUILD_DIR}/eris-client ./client/cmd/eris-client
+	go build -race -o ${BUILD_DIR}/eris-client-${COMMIT_SHA} ./client/cmd/eris-client
 
 # build eris-keys with checks for race conditions
 .PHONY: build_race_keys

--- a/Makefile
+++ b/Makefile
@@ -140,3 +140,4 @@ build_docker_db: check
 .PHONY: test_docker_db
 test_docker_db: check
 	docker build -t ${DOCKER_NAMESPACE}/db:build-${COMMIT_SHA} ${REPO}
+	docker run ${DOCKER_NAMESPACE}/db:build-${COMMIT_SHA} glide nv | xargs go test

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOFILES_NOVENDOR := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 PACKAGES_NOVENDOR := $(shell go list github.com/eris-ltd/eris-db/... | grep -v /vendor/)
 VERSION_MIN := $(shell cat ./version/version.go | tail -n 1 | cut -d \  -f 4 | tr -d '"')
 VERSION_MAJ := $(shell echo ${VERSION_MIN} | cut -d . -f 1-2)
+BUILD_DIR?=target
 
 .PHONY: greet
 greet:
@@ -43,3 +44,24 @@ lint:
 vet:
 	@echo "Running go vet."
 	@go vet ${PACKAGES_NOVENDOR}
+
+### Building code
+
+# build all targets in github.com/eris-ltd/eris-db
+.PHONY: build
+build:	build_db build_client build_keys
+
+# build eris-db
+.PHONY: build_db
+build_db:
+	go build -o ${BUILD_DIR}/eris-db ./cmd/eris-db
+
+# build eris-client
+.PHONY: build_client
+build_client:
+	go build -o ${BUILD_DIR}/eris-client ./client/cmd/eris-client
+
+# build eris-keys
+.PHONY: build_keys
+build_keys:
+	@echo "Marmots need to complete moving repository eris-keys into eris-db."

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ vet:
 .PHONY: build
 build:	build_db build_client build_keys
 
+# build all targets in github.com/eris-ltd/eris-db with checks for race conditions
+.PHONY: build_race
+build_race:	build_race_db build_race_client build_race_keys
+
 # build eris-db
 .PHONY: build_db
 build_db:
@@ -64,4 +68,19 @@ build_client:
 # build eris-keys
 .PHONY: build_keys
 build_keys:
+	@echo "Marmots need to complete moving repository eris-keys into eris-db."
+
+# build eris-db with checks for race conditions
+.PHONY: build_race_db
+build_race_db:
+	go build -race -o ${BUILD_DIR}/eris-db ./cmd/eris-db
+
+# build eris-client with checks for race conditions
+.PHONY: build_race_client
+build_race_client:
+	go build -race -o ${BUILD_DIR}/eris-client ./client/cmd/eris-client
+
+# build eris-keys with checks for race conditions
+.PHONY: build_race_keys
+build_race_keys:
 	@echo "Marmots need to complete moving repository eris-keys into eris-db."

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,20 @@ vet:
 	@echo "Running go vet."
 	@go vet ${PACKAGES_NOVENDOR}
 
-### Building code
+### Dependency amanagement for github.com/eris-ltd/eris-db
+
+# erase vendor wipes the full vendor directory
+.PHONY: erase_vendor
+erase_vendor:
+	rm -rf vendor/
+
+# install vendor uses glide to install vendored dependencies
+.PHONY: install_vendor
+install_vendor:
+	go get github.com/Masterminds/glide
+	glide install
+
+### Building github.com/eris-ltd/eris-db
 
 # build all targets in github.com/eris-ltd/eris-db
 .PHONY: build

--- a/client/client.go
+++ b/client/client.go
@@ -80,7 +80,7 @@ func NewErisNodeClient(rpcString string) *ErisNodeClient {
 // it needs to be initialised before go-rpc, hence it's placement here.
 func init() {
 	h := tendermint_log.LvlFilterHandler(tendermint_log.LvlWarn, tendermint_log.StdoutHandler)
-    tendermint_log.Root().SetHandler(h)
+	tendermint_log.Root().SetHandler(h)
 }
 
 //------------------------------------------------------------------------------------

--- a/tests/build_tool.sh
+++ b/tests/build_tool.sh
@@ -35,14 +35,15 @@ release_min=$(cat $REPO/version/version.go | tail -n 1 | cut -d \  -f 4 | tr -d 
 release_maj=$(echo $release_min | cut -d . -f 1-2)
 
 # Build
+mkdir -p $REPO/target/docker
 docker build -t $IMAGE:build $REPO
-docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/$TARGET > $REPO/"$TARGET"_build_artifact
-docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/eris-client > $REPO/eris-client
+docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/$TARGET > $REPO/target/docker/eris-db.dockerartefact
+docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/eris-client > $REPO/target/docker/eris-client.dockerartefact
 docker build -t $IMAGE:$release_min -f Dockerfile.deploy $REPO
 
 # Cleanup
-rm $REPO/"$TARGET"_build_artifact
-rm $REPO/eris-client
+rm $REPO/target/docker/eris-db.dockerartefact
+rm $REPO/target/docker/eris-client.dockerartefact
 
 # Extra Tags
 if [[ "$branch" = "release" ]]


### PR DESCRIPTION
- introduce makefile for eris-db with 
`make check` : fails on gofmt
`make fmt` : applies gofmt
`make lint` : fails on golint
`make vet` : fails on go vet
`make erase_vendor` : deletes `/vendor`, as helper to ensure CI builds have clean vendor folder installed
`make install_vendor` : installs `/vendor` from `glide.lock`
`make build` : fail on check, build all targets
`make build_race` : fail on check, build all targets with check for race conditions
`make test` : fail on check, build and run go test (for all targets)
`make test_race` : as test, but with race conditions
`make build_docker_db` : build docker image for eris-db and tag with full version number
`make test_docker_db` : build docker image for eris-db and run go test inside the docker image

note: build also builds into `/target`

this set of instructions is not set in stone or incomplete, but it aims at providing a base-line to simplify the jenkins jobs needed to build, test, move artefacts, for multiple targets in a single repository as we consolidate the repositories.