### PR TITLE
Fix for deserialization of BroadcastTx which was missing the type byte.

### DIFF
--- a/rpc/codec.go
+++ b/rpc/codec.go
@@ -9,5 +9,6 @@ type Codec interface {
 	EncodeBytes(interface{}) ([]byte, error)
 	Encode(interface{}, io.Writer) error
 	DecodeBytes(interface{}, []byte) error
+	DecodeBytesPtr(interface{}, []byte) error
 	Decode(interface{}, io.Reader) error
 }

--- a/rpc/v0/codec.go
+++ b/rpc/v0/codec.go
@@ -64,3 +64,11 @@ func (this *TCodec) DecodeBytes(v interface{}, bts []byte) error {
 	wire.ReadJSON(v, bts, &err)
 	return err
 }
+
+// Decode from a byte array pointer.
+func (this *TCodec) DecodeBytesPtr(v interface{}, bts []byte) error {
+       var err error
+       wire.ReadJSONPtr(v, bts, &err)
+       return err
+}
+

--- a/rpc/v0/methods.go
+++ b/rpc/v0/methods.go
@@ -345,12 +345,12 @@ func (erisDbMethods *ErisDbMethods) CallCode(request *rpc.RPCRequest, requester 
 }
 
 func (erisDbMethods *ErisDbMethods) BroadcastTx(request *rpc.RPCRequest, requester interface{}) (interface{}, int, error) {
-	param := &txs.CallTx{}
-	err := erisDbMethods.codec.DecodeBytes(param, request.Params)
+	param := new(txs.Tx)
+	err := erisDbMethods.codec.DecodeBytesPtr(param, request.Params)
 	if err != nil {
 		return nil, rpc.INVALID_PARAMS, err
 	}
-	receipt, errC := erisDbMethods.pipe.Transactor().BroadcastTx(param)
+	receipt, errC := erisDbMethods.pipe.Transactor().BroadcastTx(*param)
 	if errC != nil {
 		return nil, rpc.INTERNAL_ERROR, errC
 	}


### PR DESCRIPTION
This fixes an issue when deserialising a BroadcastTx json-rpc request over websockets.

Until 0.11.4, such json would be valid:

```json
{
  "id": "57EC1D39-7B3D-4F96-B286-8FC128177AFC4",
  "jsonrpc": "2.0",
  "method": "erisdb.broadcastTx",
  "params": [
    2,
    {
      "address": "5A9083BB0EFFE4C8EB2ADD29174994F73E77D418",
      "data": "2F2397A00000000000000000000000000000000000000000000000000000000000003132",
      "fee": 1,
      "gas_limit": 1000000,
      "input": {
        "address": "BE18FDCBF12BF99F4D75325E17FF2E78F1A35FE8",
        "amount": 1,
        "pub_key": [
          1,
          "8D1611925948DC2EDDF739FB65CE517757D286155A039B28441C3349BE9A8C38"
        ],
        "sequence": 2,
        "signature": [
          1,
          "B090D622F143ECEDA9B9E7B15485CE7504453C05434951CF867B013D80ED1BD2A0CA32846FC175D234CDFB9D5C3D792759E8FE79FD4DB3006B24950EE3C37D00"
        ]
      }
    }
  ]
}
```

In 0.12.0, the "params" value is wrongly expected to be a dictionary instead of the correct [ type, {dict}].
  