### PR TITLE
update JSON-RPC codec to observe specification

### DIFF
--- a/rpc/codec.go
+++ b/rpc/codec.go
@@ -1,3 +1,18 @@
+// Copyright 2015-2017 Monax Industries Limited.
+// This file is part of the Monax platform (Monax)
+
+// Monax is free software: you can use, redistribute it and/or modify
+// it only under the terms of the GNU General Public License, version
+// 3, as published by the Free Software Foundation.
+
+// Monax is distributed WITHOUT ANY WARRANTY pursuant to
+// the terms of the Gnu General Public Licence, version 3, including
+// (but not limited to) Clause 15 thereof. See the text of the
+// GNU General Public License, version 3 for full terms.
+
+// You should have received a copy of the GNU General Public License,
+// version 3, with Monax.  If not, see <http://www.gnu.org/licenses/>.
+
 package rpc
 
 import (

--- a/rpc/jsonrpc.go
+++ b/rpc/jsonrpc.go
@@ -1,3 +1,18 @@
+// Copyright 2015-2017 Monax Industries Limited.
+// This file is part of the Monax platform (Monax)
+
+// Monax is free software: you can use, redistribute it and/or modify
+// it only under the terms of the GNU General Public License, version
+// 3, as published by the Free Software Foundation.
+
+// Monax is distributed WITHOUT ANY WARRANTY pursuant to
+// the terms of the Gnu General Public Licence, version 3, including
+// (but not limited to) Clause 15 thereof. See the text of the
+// GNU General Public License, version 3 for full terms.
+
+// You should have received a copy of the GNU General Public License,
+// version 3, with Monax.  If not, see <http://www.gnu.org/licenses/>.
+
 package rpc
 
 import (
@@ -14,6 +29,7 @@ const (
 )
 
 // Request and Response objects. Id is a string. Error data not used.
+// Refer to JSON-RPC specification http://www.jsonrpc.org/specification
 type (
 	RPCRequest struct {
 		JSONRPC string          `json:"jsonrpc"`
@@ -22,35 +38,47 @@ type (
 		Id      string          `json:"id"`
 	}
 
-	RPCResponse struct {
+	// RPCResponse MUST follow the JSON-RPC specification for Response object
+	// reference: http://www.jsonrpc.org/specification#response_object
+	RPCResponse interface{}
+
+	// RPCResultResponse MUST NOT contain the error member if no error occurred
+	RPCResultResponse struct {
 		Result  interface{} `json:"result"`
-		Error   *RPCError   `json:"error"`
 		Id      string      `json:"id"`
 		JSONRPC string      `json:"jsonrpc"`
 	}
 
+	// RPCErrorResponse MUST NOT contain the result member if an error occured
+	RPCErrorResponse struct {
+		Error   *RPCError `json:"error"`
+		Id      string    `json:"id"`
+		JSONRPC string    `json:"jsonrpc"`
+	}
+
+	// RPCError MUST be included in the Response object if an error occured
 	RPCError struct {
 		Code    int    `json:"code"`
 		Message string `json:"message"`
+		// Note: Data is currently unused, and the data member may be omitted
+		// Data  interface{} `json:"data"`
 	}
 )
 
-// Create a new response object from a result.
-func NewRPCResponse(id string, res interface{}) *RPCResponse {
-	return &RPCResponse{
+// NewRPCResponse creates a new response object from a result
+func NewRPCResponse(id string, res interface{}) RPCResponse {
+	return RPCResponse(&RPCResultResponse{
 		Result:  res,
-		Error:   nil,
 		Id:      id,
 		JSONRPC: "2.0",
-	}
+	})
 }
 
-// Create a new error-response object from the error code and message.
-func NewRPCErrorResponse(id string, code int, message string) *RPCResponse {
-	return &RPCResponse{
-		Result:  nil,
+// NewRPCErrorResponse creates a new error-response object from the error code and message
+func NewRPCErrorResponse(id string, code int, message string) RPCResponse {
+	return RPCResponse(&RPCErrorResponse{
 		Error:   &RPCError{code, message},
 		Id:      id,
 		JSONRPC: "2.0",
-	}
+	})
 }

--- a/rpc/jsonrpc.go
+++ b/rpc/jsonrpc.go
@@ -40,7 +40,9 @@ type (
 
 	// RPCResponse MUST follow the JSON-RPC specification for Response object
 	// reference: http://www.jsonrpc.org/specification#response_object
-	RPCResponse interface{}
+	RPCResponse interface {
+		AssertIsRPCResponse() bool
+	}
 
 	// RPCResultResponse MUST NOT contain the error member if no error occurred
 	RPCResultResponse struct {
@@ -81,4 +83,16 @@ func NewRPCErrorResponse(id string, code int, message string) RPCResponse {
 		Id:      id,
 		JSONRPC: "2.0",
 	})
+}
+
+// AssertIsRPCResponse implements a marker method for RPCResultResponse
+// to implement the interface RPCResponse
+func (rpcResultResponse *RPCResultResponse) AssertIsRPCResponse() bool {
+	return true
+}
+
+// AssertIsRPCResponse implements a marker method for RPCErrorResponse
+// to implement the interface RPCResponse
+func (rpcErrorResponse *RPCErrorResponse) AssertIsRPCResponse() bool {
+	return true
 }

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -1,3 +1,18 @@
+// Copyright 2015-2017 Monax Industries Limited.
+// This file is part of the Monax platform (Monax)
+
+// Monax is free software: you can use, redistribute it and/or modify
+// it only under the terms of the GNU General Public License, version
+// 3, as published by the Free Software Foundation.
+
+// Monax is distributed WITHOUT ANY WARRANTY pursuant to
+// the terms of the Gnu General Public Licence, version 3, including
+// (but not limited to) Clause 15 thereof. See the text of the
+// GNU General Public License, version 3 for full terms.
+
+// You should have received a copy of the GNU General Public License,
+// version 3, with Monax.  If not, see <http://www.gnu.org/licenses/>.
+
 package rpc
 
 import (
@@ -10,12 +25,11 @@ import (
 func TestNewJsonRpcResponse(t *testing.T) {
 	id := "testId"
 	data := "a string"
-	resp := &RPCResponse{
+	resp := RPCResponse(&RPCResultResponse{
 		Result:  data,
-		Error:   nil,
 		Id:      id,
 		JSONRPC: "2.0",
-	}
+	})
 	respGen := NewRPCResponse(id, data)
 	assert.Equal(t, respGen, resp)
 }
@@ -25,12 +39,11 @@ func TestNewJsonRpcErrorResponse(t *testing.T) {
 	id := "testId"
 	code := 100
 	message := "the error"
-	resp := &RPCResponse{
-		Result:  nil,
+	resp := RPCResponse(&RPCErrorResponse{
 		Error:   &RPCError{code, message},
 		Id:      id,
 		JSONRPC: "2.0",
-	}
+	})
 	respGen := NewRPCErrorResponse(id, code, message)
 	assert.Equal(t, respGen, resp)
 }


### PR DESCRIPTION
rpc: update JSON-RPC codec to follow the specification wrt Response object;
specifically the `result` and `error` member of the Response object are mutually exclusive per http://www.jsonrpc.org/specification#response_object

fixes #464 