### PR TITLE
issue-476: return One256 for EXTCODESIZE on native contracts

### DIFF
--- a/manager/eris-mint/evm/vm.go
+++ b/manager/eris-mint/evm/vm.go
@@ -15,18 +15,19 @@ import (
 )
 
 var (
-	ErrUnknownAddress      = errors.New("Unknown address")
-	ErrInsufficientBalance = errors.New("Insufficient balance")
-	ErrInvalidJumpDest     = errors.New("Invalid jump dest")
-	ErrInsufficientGas     = errors.New("Insufficient gas")
-	ErrMemoryOutOfBounds   = errors.New("Memory out of bounds")
-	ErrCodeOutOfBounds     = errors.New("Code out of bounds")
-	ErrInputOutOfBounds    = errors.New("Input out of bounds")
-	ErrCallStackOverflow   = errors.New("Call stack overflow")
-	ErrCallStackUnderflow  = errors.New("Call stack underflow")
-	ErrDataStackOverflow   = errors.New("Data stack overflow")
-	ErrDataStackUnderflow  = errors.New("Data stack underflow")
-	ErrInvalidContract     = errors.New("Invalid contract")
+	ErrUnknownAddress         = errors.New("Unknown address")
+	ErrInsufficientBalance    = errors.New("Insufficient balance")
+	ErrInvalidJumpDest        = errors.New("Invalid jump dest")
+	ErrInsufficientGas        = errors.New("Insufficient gas")
+	ErrMemoryOutOfBounds      = errors.New("Memory out of bounds")
+	ErrCodeOutOfBounds        = errors.New("Code out of bounds")
+	ErrInputOutOfBounds       = errors.New("Input out of bounds")
+	ErrCallStackOverflow      = errors.New("Call stack overflow")
+	ErrCallStackUnderflow     = errors.New("Call stack underflow")
+	ErrDataStackOverflow      = errors.New("Data stack overflow")
+	ErrDataStackUnderflow     = errors.New("Data stack underflow")
+	ErrInvalidContract        = errors.New("Invalid contract")
+	ErrNativeContractCodeCopy = errors.New("Tried to copy native contract code, but this is not supported")
 )
 
 type ErrPermission struct {
@@ -585,7 +586,10 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value int64, gas
 			}
 			acc := vm.appState.GetAccount(addr)
 			if acc == nil {
-				return nil, firstErr(err, ErrUnknownAddress)
+				if _, ok := registeredNativeContracts[addr]; !ok {
+					return nil, firstErr(err, ErrUnknownAddress)
+				}
+				return nil, firstErr(err, ErrNativeContractCodeCopy)
 			}
 			code := acc.Code
 			memOff := stack.Pop64()

--- a/manager/eris-mint/evm/vm.go
+++ b/manager/eris-mint/evm/vm.go
@@ -27,7 +27,7 @@ var (
 	ErrDataStackOverflow      = errors.New("Data stack overflow")
 	ErrDataStackUnderflow     = errors.New("Data stack underflow")
 	ErrInvalidContract        = errors.New("Invalid contract")
-	ErrNativeContractCodeCopy = errors.New("Tried to copy native contract code, but this is not supported")
+	ErrNativeContractCodeCopy = errors.New("Tried to copy native contract code")
 )
 
 type ErrPermission struct {
@@ -571,8 +571,8 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value int64, gas
 				if _, ok := registeredNativeContracts[addr]; !ok {
 					return nil, firstErr(err, ErrUnknownAddress)
 				}
-				stack.Push64(int64(One256))
-				dbg.Printf(" => Hit native contract\n\n")
+				dbg.Printf(" => returning code size of 1 to indicated existence of native contract at %X\n", addr)
+				stack.Push(One256)
 			} else {
 				code := acc.Code
 				l := int64(len(code))
@@ -586,10 +586,11 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value int64, gas
 			}
 			acc := vm.appState.GetAccount(addr)
 			if acc == nil {
-				if _, ok := registeredNativeContracts[addr]; !ok {
-					return nil, firstErr(err, ErrUnknownAddress)
+				if _, ok := registeredNativeContracts[addr]; ok {
+					dbg.Printf(" => attempted to copy native contract at %X but this is not supported\n", addr)
+					return nil, firstErr(err, ErrNativeContractCodeCopy)
 				}
-				return nil, firstErr(err, ErrNativeContractCodeCopy)
+				return nil, firstErr(err, ErrUnknownAddress)
 			}
 			code := acc.Code
 			memOff := stack.Pop64()

--- a/manager/eris-mint/evm/vm.go
+++ b/manager/eris-mint/evm/vm.go
@@ -570,8 +570,8 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value int64, gas
 				if _, ok := registeredNativeContracts[addr]; !ok {
 					return nil, firstErr(err, ErrUnknownAddress)
 				}
-				stack.Push64(int64(1))
-				dbg.Printf(" => Hit native contract\n")
+				stack.Push64(int64(One256))
+				dbg.Printf(" => Hit native contract\n\n")
 			} else {
 				code := acc.Code
 				l := int64(len(code))

--- a/manager/eris-mint/evm/vm.go
+++ b/manager/eris-mint/evm/vm.go
@@ -567,13 +567,17 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value int64, gas
 			}
 			acc := vm.appState.GetAccount(addr)
 			if acc == nil {
-				return nil, firstErr(err, ErrUnknownAddress)
+				if _, ok := registeredNativeContracts[addr]; !ok {
+					return nil, firstErr(err, ErrUnknownAddress)
+				}
+				stack.Push64(int64(1))
+				dbg.Printf(" => Hit native contract\n")
+			} else {
+				code := acc.Code
+				l := int64(len(code))
+				stack.Push64(l)
+				dbg.Printf(" => %d\n", l)
 			}
-			code := acc.Code
-			l := int64(len(code))
-			stack.Push64(l)
-			dbg.Printf(" => %d\n", l)
-
 		case EXTCODECOPY: // 0x3C
 			addr := stack.Pop()
 			if useGasNegative(gas, GasGetAccount, &err) {


### PR DESCRIPTION
Fixes problem with not being able to get at the Snative contract. 

Signed-off-by: RJ Catalano <rj@monax.io>