### PR TITLE
carry over hotfix: correct deployment from master and release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -44,7 +44,15 @@ deployment:
       - tests/build_tool.sh
       - "docker tag quay.io/eris/db:build throw:build && docker rmi quay.io/eris/db:build"
       - docker push quay.io/eris/db
-      - docs/build.sh release
+      - docs/build.sh
+  release-0.16:
+    branch: release-0.16
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
+      - tests/build_tool.sh
+      - "docker tag quay.io/eris/db:build throw:build && docker rmi quay.io/eris/db:build"
+      - docker push quay.io/eris/db
+      - docs/build.sh
   master:
     branch: master
     commands:
@@ -52,4 +60,4 @@ deployment:
       - tests/build_tool.sh
       - "docker rmi quay.io/eris/db:latest && docker tag quay.io/eris/db:build throw:build && docker rmi quay.io/eris/db:build"
       - docker push quay.io/eris/db
-      - docs/build.sh
+      - docs/build.sh release

--- a/circle.yml
+++ b/circle.yml
@@ -41,23 +41,42 @@ deployment:
     branch: release-0.12
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
+      # build docker image and tag the image with the version
       - tests/build_tool.sh
-      - "docker tag quay.io/eris/db:build throw:build && docker rmi quay.io/eris/db:build"
       - docker push quay.io/eris/db
+      # push the updated documentation
       - docs/build.sh
   release-0.16:
     branch: release-0.16
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
+      # build docker image and tag the image with the version
       - tests/build_tool.sh
-      - "docker tag quay.io/eris/db:build throw:build && docker rmi quay.io/eris/db:build"
       - docker push quay.io/eris/db
+      # push the updated documentation
       - docs/build.sh
   master:
     branch: master
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
-      - tests/build_tool.sh
-      - "docker rmi quay.io/eris/db:latest && docker tag quay.io/eris/db:build throw:build && docker rmi quay.io/eris/db:build"
+      # build docker image and tag the image with ':latest'
+      # builds on master are considered immutable so we do not push the version
+      # tag to allow for hotfixes
+      - tests/build_tool.sh latest
       - docker push quay.io/eris/db
-      - docs/build.sh release
+      # push the updated documentation and replace latest
+      - docs/build.sh latest
+  tagged-releases:
+    tag: /v[0-9]+(\.[0-9]+)*/
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
+      # build docker image and tag the image with the version;
+      # once the commit is tagged the docker image for this version tag is
+      # considered immutable.
+      - tests/build_tool.sh
+      - docker push quay.io/eris/db
+      # push the updated documentation
+      - docs/build.sh
+
+
+

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -28,7 +28,7 @@ cd $repo
 rm -rf $docs_name
 go run ./docs/generator.go
 
-if [[ "$1" == "release" ]]
+if [[ "$1" == "latest" ]]
 then
   mkdir -p $docs_name/$slim_name/latest
   rsync -av $docs_name/$slim_name/$release_min/ $docs_name/$slim_name/latest/

--- a/tests/build_tool.sh
+++ b/tests/build_tool.sh
@@ -41,18 +41,14 @@ docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/$TARGET > $REPO/tar
 docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/eris-client > $REPO/target/docker/eris-client.dockerartefact
 docker build -t $IMAGE:$release_min -f Dockerfile.deploy $REPO
 
+# If provided, tag the image with the label provided
+if [ "$1" ]
+then
+  docker tag $IMAGE:$release_min $IMAGE:$1
+  docker rmi $IMAGE:$release_min
+fi
+
 # Cleanup
-rm $REPO/target/docker/eris-db.dockerartefact
-rm $REPO/target/docker/eris-client.dockerartefact
-
-# Extra Tags
-if [[ "$branch" = "release" ]]
-then
-  docker tag -f $IMAGE:$release_min $IMAGE:$release_maj
-  docker tag -f $IMAGE:$release_min $IMAGE:latest
-fi
-
-if [ "$CIRCLE_BRANCH" ]
-then
-  docker tag -f $IMAGE:$release_min $IMAGE:latest
-fi
+rm $REPO/"$TARGET"_build_artifact
+rm $REPO/eris-client
+docker rmi $IMAGE:build


### PR DESCRIPTION
circle: deploy artefacts from release and docs from master

master branch : push docker image with `:latest` + update documentation for `/latest`
release branch : push docker image with _mutable_ `v0.16.x` + update documentation
develop: don't push docker artefact or update documentation

for tagged commits of the form `v0.16.x` (or generalisations):
  push docker image with _immutable_ version tag + update documentation