### PR TITLE
Issue434: cleanup comments with respect to internal time

### DIFF
--- a/manager/eris-mint/eris-mint.go
+++ b/manager/eris-mint/eris-mint.go
@@ -168,13 +168,13 @@ func (app *ErisMint) Commit() (res tmsp.Result) {
 	// flush events to listeners (XXX: note issue with blocking)
 	app.evc.Flush()
 
-	// MARMOT:
-	// set internal time as two seconds per block
+	// TODO: [ben] over the tendermint 0.6 TMSP interface we have 
+	// no access to the block header implemented;
+	// On Tendermint v0.8 load the blockheader into the application
+	// state and remove the fixed 2-"seconds" per block internal clock.
+	// NOTE: set internal time as two seconds per block
 	app.state.LastBlockTime = app.state.LastBlockTime.Add(time.Duration(2) * time.Second)
-	fmt.Printf("\n\nMARMOT TIME: %s\n\n", app.state.LastBlockTime)
-	// MARMOT:
 	appHash := app.state.Hash()
-	fmt.Printf("\n\nMARMOT COMMIT: %X\n\n", appHash)
 	// return tmsp.NewResultOK(app.state.Hash(), "Success")
 	return tmsp.NewResultOK(appHash, "Success")
 }

--- a/manager/eris-mint/state/state.go
+++ b/manager/eris-mint/state/state.go
@@ -416,10 +416,12 @@ func MakeGenesisState(db dbm.DB, genDoc *genesis.GenesisDoc) *State {
 	}
 
 	if genDoc.GenesisTime.IsZero() {
-		// MARMOT: really?
-		// set time to 11/18/2016 @ 4:09am (UTC)
+		// NOTE: [ben] change GenesisTime to requirement on v0.17
+		// GenesisTime needs to be deterministic across the chain
+		// and should be required in the genesis file;
+		// the requirement is not yet enforced when lacking set
+		// time to 11/18/2016 @ 4:09am (UTC)
 		genDoc.GenesisTime = time.Unix(1479442162, 0)
-		// genDoc.GenesisTime = time.Now()
 	}
 
 	// Make accounts state tree


### PR DESCRIPTION
Improve comments with respect to impending work for internal time on v0.16
continues #434 
