### PR TITLE
fixes genesis so that tendermint consensus module lines up correctly

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -96,7 +96,7 @@ func GetConfigurationFileBytes(chainId, moniker, seeds string, chainImageName st
 	chainConsensusModule := &ConfigChainModule{
 		Name:               "tendermint",
 		MajorVersion:       uint8(0),
-		MinorVersion:       uint8(6),
+		MinorVersion:       uint8(8),
 		ModuleRelativeRoot: "tendermint",
 	}
 	chainApplicationManagerModule := &ConfigChainModule{


### PR DESCRIPTION
This is a small oversight that causes Eris CLI to fail in working with chains with current docker images. 

Signed-off-by: RJ Catalano <rj@monax.io>